### PR TITLE
WIP/RFC State Hooks

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,0 +1,80 @@
+export function createChild(plugin?: string) {
+  return (blackbox: Blackbox<T>) => {
+    const [ render, remove ] = useChild(blackbox, plugin)
+
+    return {
+      render,
+      remove
+    }
+  }
+}
+
+export function useChild(
+  blackbox: Blackbox<unknown>,
+  plugin?: string
+): [() => React.ReactNode, () => void] {
+  return [
+    () => {
+      return null
+    },
+    () => {}
+  ]
+}
+
+export function createLeaf<T>(initialValue?: T) {
+  return (blackbox: Blackbox<T>) => {
+    const [value, setValue] = useLeaf(blackbox, initialValue)
+
+    return {
+      value,
+      setValue
+    }
+  }
+}
+
+export function useLeaf<T>(
+  blackbox: Blackbox<T>,
+  initialValue?: T
+): [T, (value: T) => void] {
+  // @ts-ignore
+  return [null, () => {}]
+}
+
+export type HookReturnType<
+  T extends {
+    key: string
+    hook: Hook<any>
+  }
+  > = T['hook'] extends Hook<any, infer R> ? R : never
+
+export function createObject(
+  hooks: Array<{
+    key: string
+    hook: Hook<any>
+  }>
+) {
+  return (blackbox: Blackbox<unknown>): unknown => {
+    return null
+  }
+}
+
+export function createList(
+  hooks: Hook<any>
+)
+{
+  return (blackbox: Blackbox<unknown>): [
+    unknown[],
+    (atIndex?: number) => {},
+    (removeIndex: number) => {}
+    ] => {
+    // @ts-ignore
+    return null
+  }
+}
+
+export interface Blackbox<T = unknown> {
+  children: unknown[]
+  value?: T
+}
+
+export type Hook<T, R = unknown> = (blackbox: Blackbox<T>) => R

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -12,4 +12,5 @@ export {
   StatefulPlugin,
   StatelessPlugin
 } from './plugin'
+export * from './hooks'
 export { serializeDocument } from './store'


### PR DESCRIPTION
Adds a "React Hook"-like API for plugin developers. Motivation is similar to React Hooks, i.e. we want reusable, composable parts that abstract the editor complexity away (e.g. Dnd behaviour, focus behaviour, ...).

### `useLeaf` represents a single value in state

API is basically `React.useState` (with an added first parameter that the editor needs to handle state updating, serialization, ...) 

#### Usage
```.js
function CounterPlugin(props) {
  const [value, setValue] = useLeaf(
    props, /* "blackbox": contains state and onChange. */
    0 /* initial value */
  )

  return (
    <button onClick={() => setValue(value + 1)}>Increment</button>
  )
}
```

### `useChild` represents a sub document

#### Usage

```.js
function Spoiler(props) {
  const [renderContent, remove] = useChild(
    props  /* "blackbox": contains state and onChange. */,
    "text" /* optional plugin (defaults to the default editor plugin) */ 
  )

  return (
    <React.Fragment>
      {renderContent()}
    </React.Fragment>
  )
}
```

### `createObject` composes stuff together in an object


#### Usage

```.js
function Spoiler(props) {
  const state = createObject([
    { key: "title", hook: createLeaf("placeholder") },
    { key: "content": hook: createChild() }
  ])(props)

  // e.g. in some `onChange` handler:
  // state.title.setValue("foobar")

  return (
    <React.Fragment>
      <h1>{state.title.value}</h1>
      {state.content.render()}
    </React.Fragment>
  )
}
```

### `createList` represents a collection of items

#### Usage
```.js
function Rows(props) {
  const { items, insert, remove } = createList(createChild())(props)

  return items.map((item, key) => {
    return <React.Fragment key={key}>{item.render()}</React.Fragment>
  })
}
```


