### PR TITLE
feature: debounce undo/redo

### DIFF
--- a/packages/core/__tests__/plugin-state.ts
+++ b/packages/core/__tests__/plugin-state.ts
@@ -253,9 +253,11 @@ function createStateContainer<T, S>(initialValue: T | undefined) {
     state = value
   }
 
+  const dispatch = () => {}
+
   return {
     get(): StateType.PluginStateParameters<T, S> {
-      return [initialValue, state, onChange]
+      return [initialValue, state, onChange, dispatch]
     },
     reset() {
       state = undefined

--- a/packages/core/__tests__/store/index.ts
+++ b/packages/core/__tests__/store/index.ts
@@ -337,7 +337,8 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 1 })
-      }
+      },
+      forceCommit: true
     })
     state = reducer(state, {
       type: ActionType.Undo
@@ -351,7 +352,8 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 2 })
-      }
+      },
+      forceCommit: true
     })
 
     if (!state.history) throw new Error('history not initialized')
@@ -369,8 +371,7 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 1 })
-      },
-      debounce: true
+      }
     })
     if (!state.history) throw new Error('history not initialized')
     expect(state.history.actions).toHaveLength(1)
@@ -379,8 +380,7 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 2 })
-      },
-      debounce: true
+      }
     })
     if (!state.history) throw new Error('history not initialized')
     expect(state.history.actions).toHaveLength(1)
@@ -389,7 +389,8 @@ describe('history', () => {
       type: ActionType.Insert,
       payload: {
         id: '1'
-      }
+      },
+      forceCommit: true
     })
     if (!state.history) throw new Error('history not initialized')
     expect(state.history.actions).toHaveLength(2)
@@ -397,8 +398,7 @@ describe('history', () => {
       type: ActionType.Insert,
       payload: {
         id: '1'
-      },
-      debounce: true
+      }
     })
     if (!state.history) throw new Error('history not initialized')
     expect(state.history.actions).toHaveLength(3)
@@ -414,14 +414,16 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 1 })
-      }
+      },
+      forceCommit: true
     })
     state = reducer(state, {
       type: ActionType.Change,
       payload: {
         id: '0',
         state: () => ({ counter: 2 })
-      }
+      },
+      forceCommit: true
     })
     state = reducer(state, {
       type: ActionType.Undo
@@ -443,14 +445,16 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 1 })
-      }
+      },
+      forceCommit: true
     })
     state = reducer(state, {
       type: ActionType.Change,
       payload: {
         id: '0',
         state: () => ({ counter: 2 })
-      }
+      },
+      forceCommit: true
     })
     state = reducer(state, {
       type: ActionType.Undo
@@ -475,16 +479,14 @@ describe('history', () => {
       payload: {
         id: '0',
         state: () => ({ counter: 1 })
-      },
-      debounce: true
+      }
     })
     state = reducer(state, {
       type: ActionType.Change,
       payload: {
         id: '0',
         state: () => ({ counter: 2 })
-      },
-      debounce: true
+      }
     })
 
     state = reducer(state, {

--- a/packages/core/__tests__/store/index.ts
+++ b/packages/core/__tests__/store/index.ts
@@ -386,18 +386,20 @@ describe('history', () => {
     expect(state.history.actions).toHaveLength(1)
 
     state = reducer(state, {
-      type: ActionType.Insert,
+      type: ActionType.Change,
       payload: {
-        id: '1'
+        id: '0',
+        state: () => ({ counter: 4 })
       },
       forceCommit: true
     })
     if (!state.history) throw new Error('history not initialized')
     expect(state.history.actions).toHaveLength(2)
     state = reducer(state, {
-      type: ActionType.Insert,
+      type: ActionType.Change,
       payload: {
-        id: '1'
+        id: '0',
+        state: () => ({ counter: 2 })
       }
     })
     if (!state.history) throw new Error('history not initialized')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,6 @@
   "repository": "edtr-io/edtr-io",
   "scripts": {},
   "dependencies": {
-    "immer": "^1.0.0",
     "ramda": "^0.26.0",
     "react-hotkeys": "^1.1.4",
     "uuid": "^3.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "immer": "^1.0.0",
     "ramda": "^0.26.0",
+    "react-hotkeys": "^1.1.4",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -54,7 +54,8 @@ export const DocumentEditor: React.FunctionComponent<
             ...identifier,
             plugin: identifier.plugin || store.state.defaultPlugin,
             state: state.$$value
-          }
+          },
+          forceCommit: true
         })
       } else {
         store.dispatch({
@@ -62,7 +63,8 @@ export const DocumentEditor: React.FunctionComponent<
           payload: {
             ...identifier,
             plugin: identifier.plugin || store.state.defaultPlugin
-          }
+          },
+          forceCommit: true
         })
       }
     }
@@ -104,8 +106,7 @@ export const DocumentEditor: React.FunctionComponent<
         payload: {
           id,
           state: stateHandler
-        },
-        debounce: true
+        }
       })
     }
     state = plugin.state(identifier.state, document.state, onChange)
@@ -143,7 +144,8 @@ export const DocumentEditor: React.FunctionComponent<
               })
               store.dispatch({
                 type: ActionType.Insert,
-                payload: subDocument
+                payload: subDocument,
+                forceCommit: true
               })
               return subDocument
             }

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -104,7 +104,8 @@ export const DocumentEditor: React.FunctionComponent<
         payload: {
           id,
           state: stateHandler
-        }
+        },
+        debounce: true
       })
     }
     state = plugin.state(identifier.state, document.state, onChange)

--- a/packages/core/src/editor-context.tsx
+++ b/packages/core/src/editor-context.tsx
@@ -6,7 +6,16 @@ export const EditorContext = React.createContext<EditorContextValue>({
   state: {
     defaultPlugin: '',
     plugins: {},
-    documents: {}
+    documents: {},
+    history: {
+      initialState: {
+        defaultPlugin: '',
+        plugins: {},
+        documents: {}
+      },
+      actions: [],
+      redoStack: []
+    }
   },
   dispatch: () => {}
 })

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -6,9 +6,17 @@ import { ActionType, reducer } from './store'
 import { Plugin } from './plugin'
 
 export function Editor<K extends string = string>(props: EditorProps<K>) {
-  const [state, dispatch] = React.useReducer(reducer, {
+  const baseState = {
     ...props,
     documents: {}
+  }
+  const [state, dispatch] = React.useReducer(reducer, {
+    ...baseState,
+    history: {
+      initialState: baseState,
+      actions: [],
+      redoStack: []
+    }
   })
 
   return (

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
+import { HotKeys } from 'react-hotkeys'
 import { Document, DocumentIdentifier } from './document'
 import { EditorContext } from './editor-context'
-import { reducer } from './store'
+import { ActionType, reducer } from './store'
 import { Plugin } from './plugin'
 
 export function Editor<K extends string = string>(props: EditorProps<K>) {
@@ -11,15 +12,32 @@ export function Editor<K extends string = string>(props: EditorProps<K>) {
   })
 
   return (
-    <EditorContext.Provider
-      value={{
-        state,
-        dispatch
+    <HotKeys
+      keyMap={{
+        UNDO: 'mod+z',
+        REDO: ['mod+y', 'mod+shift+z']
+      }}
+      handlers={{
+        UNDO: () =>
+          dispatch({
+            type: ActionType.Undo
+          }),
+        REDO: () =>
+          dispatch({
+            type: ActionType.Redo
+          })
       }}
     >
-      <Document state={props.state} />
-      {props.children}
-    </EditorContext.Provider>
+      <EditorContext.Provider
+        value={{
+          state,
+          dispatch
+        }}
+      >
+        <Document state={props.state} />
+        {props.children}
+      </EditorContext.Provider>
+    </HotKeys>
   )
 }
 

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -15,4 +15,4 @@ export {
 } from './plugin'
 import * as StateType from './plugin-state'
 export { StateType }
-export { serializeDocument } from './store'
+export { ActionType, serializeDocument } from './store'

--- a/packages/core/src/plugin-state.ts
+++ b/packages/core/src/plugin-state.ts
@@ -188,9 +188,7 @@ export function list<D extends PluginStateDescriptor>(
         R.reduce(
           (act1: Action[], act2: Action[]) => [...act1, ...act2],
           [] as Action[],
-          rawState.map(s => {
-            return s.value.$$insert() as Action[]
-          })
+          items.map(item => item.$$insert())
         ),
       $$value: rawState,
       items,
@@ -304,7 +302,7 @@ export function object<
             return [...act1, ...act2]
           },
           [] as Action[],
-          R.map(s => s.$$insert() as Action[], R.values(value))
+          R.map(s => s.$$insert(), R.values(value))
         ),
       $$value: R.mapObjIndexed(
         value => value.$$value,

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -106,12 +106,12 @@ export function reducer(state: State, action: Action): State {
         }
         debounceTimeout = null
       }
-      if (action.debounce) {
+      if (!action.forceCommit) {
         if (debounceTimeout && draft.history.actions.length) {
           clearTimeout(debounceTimeout)
           const latestActions =
             draft.history.actions[draft.history.actions.length - 1]
-          if (latestActions[latestActions.length - 1].debounce) {
+          if (!latestActions[latestActions.length - 1].forceCommit) {
             latestActions.push(action)
             return
           }
@@ -120,7 +120,7 @@ export function reducer(state: State, action: Action): State {
           debounceTimeout = null
         }, 1000)
       }
-      // debounce not allowed for the action or timeout
+      // forced commit or timeout
       draft.history.actions.push([action])
       draft.history.redoStack = []
     }
@@ -140,7 +140,7 @@ export interface State {
   }
 }
 export type Undoable = (InsertAction | ChangeAction | RemoveAction) & {
-  debounce?: boolean
+  forceCommit?: boolean
 }
 export type Action = Undoable | FocusAction | UndoAction | RedoAction
 

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -40,14 +40,12 @@ export function reducer(state: State, action: Action): State {
           plugin: type,
           state
         }
-        save(action)
       }
     }
 
     function handleRemove() {
       if (action.type === ActionType.Remove) {
         delete draft.documents[action.payload]
-        save(action)
       }
     }
 
@@ -92,7 +90,7 @@ export function reducer(state: State, action: Action): State {
         const redoing = draft.history.redoStack.pop()
         if (redoing) {
           draft.history.actions.push(redoing)
-          draft.documents = R.reduce(reducer, state, redoing).documents
+          draft.documents = R.reduce(reducer, draft, redoing).documents
         }
       }
     }
@@ -109,6 +107,9 @@ export function reducer(state: State, action: Action): State {
       if (!action.forceCommit) {
         if (debounceTimeout && draft.history.actions.length) {
           clearTimeout(debounceTimeout)
+          debounceTimeout = setTimeout(() => {
+            debounceTimeout = null
+          }, 1000)
           const latestActions =
             draft.history.actions[draft.history.actions.length - 1]
           if (!latestActions[latestActions.length - 1].forceCommit) {

--- a/packages/demo/__stories__/index.tsx
+++ b/packages/demo/__stories__/index.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionType,
   createDocument,
   DocumentIdentifier,
   Editor,
@@ -52,6 +53,7 @@ storiesOf('EditorProvider', module).add('Counter', () => {
   return (
     <Editor plugins={plugins} defaultPlugin="stateless" state={state}>
       <LogState state={state} />
+      <UndoRedoButtons />
     </Editor>
   )
 })
@@ -67,6 +69,7 @@ storiesOf('RowsPlugin', module)
     return (
       <Editor plugins={plugins} defaultPlugin="counter" state={state}>
         <LogState state={state} />
+        <UndoRedoButtons />
       </Editor>
     )
   })
@@ -78,6 +81,7 @@ storiesOf('RowsPlugin', module)
     return (
       <Editor plugins={plugins} defaultPlugin="counter" state={state}>
         <LogState state={state} />
+        <UndoRedoButtons />
       </Editor>
     )
   })
@@ -102,5 +106,31 @@ export function LogState({ state }: { state: DocumentIdentifier }) {
         )
       }}
     </EditorContext.Consumer>
+  )
+}
+
+export function UndoRedoButtons() {
+  const store = React.useContext(EditorContext)
+  return (
+    <React.Fragment>
+      <button
+        onClick={() => {
+          store.dispatch({
+            type: ActionType.Undo
+          })
+        }}
+      >
+        Undo
+      </button>
+      <button
+        onClick={() => {
+          store.dispatch({
+            type: ActionType.Redo
+          })
+        }}
+      >
+        Redo
+      </button>
+    </React.Fragment>
   )
 }

--- a/packages/demo/__stories__/textPlugin.tsx
+++ b/packages/demo/__stories__/textPlugin.tsx
@@ -3,7 +3,7 @@ import { createDocument, Editor, Plugin } from '@edtr-io/core'
 import { storiesOf } from '@storybook/react'
 import { textPlugin } from '@edtr-io/plugin-text'
 import { Overlay, rowsPlugin } from '@edtr-io/ui'
-import { LogState } from '.'
+import { LogState, UndoRedoButtons } from '.'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const plugins: Record<string, Plugin<any>> = {
@@ -21,6 +21,7 @@ storiesOf('TextPlugin', module)
       <Editor plugins={plugins} defaultPlugin="text" state={state}>
         <LogState state={state} />
         <Overlay />
+        <UndoRedoButtons />
       </Editor>
     )
   })
@@ -35,6 +36,7 @@ storiesOf('TextPlugin', module)
       <Editor plugins={plugins} defaultPlugin="text" state={state}>
         <LogState state={state} />
         <Overlay />
+        <UndoRedoButtons />
       </Editor>
     )
   })

--- a/packages/plugin-text/src/factory/editor.tsx
+++ b/packages/plugin-text/src/factory/editor.tsx
@@ -14,13 +14,11 @@ export const createTextEditor = (
   return function SlateEditor(props: SlateEditorProps) {
     const [value, setValue] = React.useState(Value.fromJSON(props.state.value))
     const lastValue = React.useRef<ValueJSON>(props.state.value)
-    // const { state, editable, focused } = this.props
-    // console.log(state)
     React.useEffect(() => {
       if (lastValue.current !== props.state.value) {
         setValue(Value.fromJSON(props.state.value))
       }
-    }, [])
+    }, [lastValue, props.state.value])
 
     return (
       <Editor

--- a/packages/plugin-text/src/factory/editor.tsx
+++ b/packages/plugin-text/src/factory/editor.tsx
@@ -17,6 +17,7 @@ export const createTextEditor = (
     React.useEffect(() => {
       if (lastValue.current !== props.state.value) {
         setValue(Value.fromJSON(props.state.value))
+        lastValue.current = props.state.value
       }
     }, [lastValue, props.state.value])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7736,6 +7736,21 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -8224,6 +8239,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+mousetrap@^1.5.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.2.tgz#caadd9cf886db0986fb2fee59a82f6bd37527587"
+  integrity sha512-jDjhi7wlHwdO6q6DS7YRmSHcuI+RVxadBkLt3KHrhd3C2b+w5pKefg3oj5beTcHZyVFA9Aksf+yEE1y5jxUjVA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -9734,6 +9754,17 @@ react-fuzzy@^0.5.2:
     classnames "^2.2.5"
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
+
+react-hotkeys@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-1.1.4.tgz#a0712aa2e0c03a759fd7885808598497a4dace72"
+  integrity sha1-oHEqouDAOnWf14hYCFmEl6TaznI=
+  dependencies:
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isobject "^3.0.2"
+    mousetrap "^1.5.2"
+    prop-types "^15.6.0"
 
 react-immutable-proptypes@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,11 +6321,6 @@ immer@1.7.2:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.7.2.tgz#a51e9723c50b27e132f6566facbec1c85fc69547"
   integrity sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA==
 
-immer@^1.0.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.12.1.tgz#40c6e5b292c00560836c2993bda3a24379d466f5"
-  integrity sha512-3fmKM6ovaqDt0CdC9daXpNi5x/YCYS3i4cwLdTVkhJdk5jrDXoPs7lCm3IqM3yhfSnz4tjjxbRG2CziQ7m8ztg==
-
 immutable@^3.8.1, immutable@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"


### PR DESCRIPTION
Follow up to #22: Debounce actions for undo/redo.
Actions can specify if they can be debounced or not. I added debounce to the Change Actions but not Insert or Remove.
Actions that don't have debounce set are commited as array of length 1, debounced append to last debounced actions if timeout isn't expired yet.