### PR TITLE
Feat: Add changed callback to editor props

### DIFF
--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -157,7 +157,6 @@ export const DocumentEditor: React.FunctionComponent<
               store.dispatch({
                 type: ActionType.Insert,
                 payload: subDocument
-                // forceCommit: true
               })
               return subDocument
             }

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -56,7 +56,6 @@ export const DocumentEditor: React.FunctionComponent<
             state: state.$$value
           }
         })
-        R.forEach(store.dispatch, state.$$insert())
       } else {
         store.dispatch({
           type: ActionType.Insert,
@@ -66,6 +65,9 @@ export const DocumentEditor: React.FunctionComponent<
           }
         })
       }
+      store.dispatch({
+        type: ActionType.ResetHistory
+      })
     }
   }, [identifier])
   const document = getDocument(store.state, id)

--- a/packages/core/src/editor-context.tsx
+++ b/packages/core/src/editor-context.tsx
@@ -14,7 +14,8 @@ export const EditorContext = React.createContext<EditorContextValue>({
         documents: {}
       },
       actions: [],
-      redoStack: []
+      redoStack: [],
+      pending: 0
     }
   },
   dispatch: () => {}

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -2,12 +2,14 @@ import * as React from 'react'
 import { HotKeys } from 'react-hotkeys'
 import { Document, DocumentIdentifier } from './document'
 import { EditorContext } from './editor-context'
-import { ActionType, reducer } from './store'
+import { ActionType, BaseState, hasUnpersistedChanges, reducer } from './store'
 import { Plugin } from './plugin'
 
 export function Editor<K extends string = string>(props: EditorProps<K>) {
-  const baseState = {
-    ...props,
+  const { plugins, defaultPlugin } = props
+  const baseState: BaseState = {
+    plugins,
+    defaultPlugin,
     documents: {}
   }
   const [state, dispatch] = React.useReducer(reducer, {
@@ -18,6 +20,10 @@ export function Editor<K extends string = string>(props: EditorProps<K>) {
       redoStack: []
     }
   })
+
+  if (props.changed) {
+    props.changed(hasUnpersistedChanges(state))
+  }
 
   return (
     <HotKeys
@@ -54,4 +60,5 @@ export interface EditorProps<K extends string = string> {
   plugins: Record<K, Plugin>
   defaultPlugin: K
   state: DocumentIdentifier
+  changed?: (changed: boolean) => void
 }

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { HotKeys } from 'react-hotkeys'
 import { Document, DocumentIdentifier } from './document'
 import { EditorContext } from './editor-context'
-import { ActionType, BaseState, hasUnpersistedChanges, reducer } from './store'
+import { ActionType, BaseState, hasPendingChanges, reducer } from './store'
 import { Plugin } from './plugin'
 
 export function Editor<K extends string = string>(props: EditorProps<K>) {
@@ -17,12 +17,13 @@ export function Editor<K extends string = string>(props: EditorProps<K>) {
     history: {
       initialState: baseState,
       actions: [],
-      redoStack: []
+      redoStack: [],
+      pending: 0
     }
   })
 
   if (props.changed) {
-    props.changed(hasUnpersistedChanges(state))
+    props.changed(hasPendingChanges(state))
   }
 
   return (

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -15,4 +15,4 @@ export {
 } from './plugin'
 import * as StateType from './plugin-state'
 export { StateType }
-export { ActionType, serializeDocument } from './store'
+export { ActionType, ActionCommitType, serializeDocument } from './store'

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -10,7 +10,8 @@ export enum ActionType {
   Focus = 'Focus',
   Undo = 'Undo',
   Redo = 'Redo',
-  Persist = 'Persist'
+  Persist = 'Persist',
+  ResetHistory = 'ResetHistory'
 }
 export enum ActionCommitType {
   ForceCommit = 'ForceCommit'
@@ -47,6 +48,8 @@ export function reducer(state: BaseState | State, action: Action): State {
       return handleRedo(state)
     case ActionType.Persist:
       return handlePersist(state)
+    case ActionType.ResetHistory:
+      return handleResetHistory(state)
   }
 }
 
@@ -211,6 +214,23 @@ function handlePersist(state: State): State {
     }
   }
 }
+
+function handleResetHistory(state: State): State {
+  return {
+    ...state,
+    history: {
+      initialState: {
+        defaultPlugin: state.defaultPlugin,
+        plugins: state.plugins,
+        documents: state.documents,
+        focus: state.focus
+      },
+      actions: [],
+      redoStack: [],
+      pending: 0
+    }
+  }
+}
 export interface BaseState {
   defaultPlugin: PluginType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -241,6 +261,7 @@ export type Action =
   | UndoAction
   | RedoAction
   | PersistAction
+  | ResetHistoryAction
 
 type PluginType = string
 
@@ -279,6 +300,10 @@ export interface RedoAction {
 
 export interface PersistAction {
   type: ActionType.Persist
+}
+
+export interface ResetHistoryAction {
+  type: ActionType.ResetHistory
 }
 
 export interface PluginState {

--- a/packages/demo/__stories__/index.tsx
+++ b/packages/demo/__stories__/index.tsx
@@ -1,6 +1,5 @@
 import {
   ActionType,
-  ActionCommitType,
   createDocument,
   DocumentIdentifier,
   Editor,
@@ -122,8 +121,7 @@ export function UndoRedoButtons(props: { enablePersist?: boolean }) {
       <button
         onClick={() => {
           store.dispatch({
-            type: ActionType.Persist,
-            commit: ActionCommitType.ForceCombine
+            type: ActionType.Persist
           })
         }}
         disabled={!props.enablePersist}

--- a/packages/demo/__stories__/textPlugin.tsx
+++ b/packages/demo/__stories__/textPlugin.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react'
-import { createDocument, Editor, Plugin } from '@edtr-io/core'
+import { createDocument } from '@edtr-io/core'
 import { storiesOf } from '@storybook/react'
-import { textPlugin } from '@edtr-io/plugin-text'
-import { Overlay, rowsPlugin } from '@edtr-io/ui'
-import { LogState, UndoRedoButtons } from '.'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const plugins: Record<string, Plugin<any>> = {
-  text: textPlugin,
-  rows: rowsPlugin
-}
+import { Story } from '.'
 
 storiesOf('TextPlugin', module)
   .add('Empty example', () => {
@@ -17,13 +9,7 @@ storiesOf('TextPlugin', module)
       plugin: 'rows'
     })
 
-    return (
-      <Editor plugins={plugins} defaultPlugin="text" state={state}>
-        <LogState state={state} />
-        <Overlay />
-        <UndoRedoButtons />
-      </Editor>
-    )
+    return <Story defaultPlugin="text" state={state} />
   })
   .add('Prefilled', () => {
     const state = createDocument(
@@ -32,11 +18,5 @@ storiesOf('TextPlugin', module)
       )
     )
 
-    return (
-      <Editor plugins={plugins} defaultPlugin="text" state={state}>
-        <LogState state={state} />
-        <Overlay />
-        <UndoRedoButtons />
-      </Editor>
-    )
+    return <Story defaultPlugin="text" state={state} />
   })

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -37,7 +37,9 @@ async function exec(): Promise<void> {
     {
       added: [
         'Slate Rich-Text plugin',
-        'Added Undo and Redo to reducer'
+        'Added Undo and Redo to reducer',
+        'Added Persist to reducer',
+        'Added `changed` callback to Editor. The callback is called on every Action passing a boolean if the content changed since the last `PersistAction` was dispatched.'
       ]
     }
   ])


### PR DESCRIPTION
## Added:
- Added `PersistAction` to reducer.
- Added `changed` callback to Editor. The callback is called on every Action passing a boolean if the content changed since the last `PersistAction` was dispatched (or initial state).