### PR TITLE
 fix: only trigger changed callback when pending changes are different 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 
 - State Descriptors uniformly return their value/items/object by invoking the state.
 
+### Fixed
+
+- Only trigger `changed` if the number of pending changes changed
+
 ## [0.2.1](https://github.com/edtr-io/edtr-io/compare/0.2.0..0.2.1) - February 28, 2019
 
 ### Added

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -7,7 +7,8 @@ import {
   hasPendingChanges,
   reducer,
   createInitialState,
-  getRoot
+  getRoot,
+  pendingChanges
 } from './store'
 import { Plugin } from './plugin'
 
@@ -32,8 +33,10 @@ export function Editor<K extends string = string>({
 
   const id = getRoot(state)
 
+  const pending = React.useRef(0)
   React.useEffect(() => {
-    if (changed) {
+    if (changed && pending.current !== pendingChanges(state)) {
+      pending.current = pendingChanges(state)
       changed(hasPendingChanges(state))
     }
   }, [changed, state])

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -512,6 +512,9 @@ export function isFocused(state: State, id: string): boolean {
 export function hasPendingChanges(state: State): boolean {
   return state.history.pending !== 0
 }
+export function pendingChanges(state: State): number {
+  return state.history.pending
+}
 
 export function serializeDocument(state: State): PluginState | null {
   const root = getRoot(state)

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -53,6 +53,9 @@ async function exec(): Promise<void> {
       changed: [
         'State Descriptors uniformly return their value/items/object by invoking the state.'
       ],
+      fixed: [
+        'Only trigger `changed` if the number of pending changes changed'
+      ],
       breakingChanges: [
         'Removed `DocumentIdentifier`. You should pass the state to `<Editor />` instead',
         'Removed `state` prop from `Document`. You should pass only the id as `id` prop instead.',


### PR DESCRIPTION
depends on #33 