### PR TITLE
Fix: serialize of nested children

### DIFF
--- a/packages/core/__tests__/store/index.ts
+++ b/packages/core/__tests__/store/index.ts
@@ -230,6 +230,47 @@ describe('serialize', () => {
       }
     })
   })
+
+  test('nested inside nested', () => {
+    state = reducer(state, {
+      type: ActionType.InitRoot,
+      payload: {
+        plugin: 'nestedArray',
+        state: {
+          children: [
+            { plugin: 'stateful', state: 1 },
+            {
+              plugin: 'nested',
+              state: {
+                child: {
+                  plugin: 'stateful',
+                  state: 2
+                }
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    expect(serializeDocument(state)).toEqual({
+      plugin: 'nestedArray',
+      state: {
+        children: [
+          {
+            plugin: 'stateful',
+            state: 1
+          },
+          {
+            plugin: 'nested',
+            state: {
+              child: { plugin: 'stateful', state: 2 }
+            }
+          }
+        ]
+      }
+    })
+  })
 })
 
 describe('history', () => {

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -564,7 +564,7 @@ export function serializePlugin(state: State, id: string): PluginState | null {
   }
 
   const serializeHelpers: StoreSerializeHelpers = {
-    getDocument: (id: string) => getDocument(state, id)
+    getDocument: (id: string) => serializePlugin(state, id)
   }
   return {
     plugin: document.plugin,


### PR DESCRIPTION
Children didn't serialize the document. Fixed by passing a correct SerializeHelper
(builds up on #35 because I needed `serializePlugin` which I added there)