### PR TITLE
Change rows menu appearance from fixed to absolute

### DIFF
--- a/packages/plugin-rows/src/editor.tsx
+++ b/packages/plugin-rows/src/editor.tsx
@@ -74,7 +74,7 @@ const RightFloatingButtonContainer = styled(FloatingButtonContainer)({
 const AddMenuContainer = styled.div((props: ThemeProps<EditorTheming>) => {
   return {
     margin: '0 auto',
-    position: 'fixed',
+    position: 'absolute',
     backgroundColor: props.theme.backgroundColor,
     color: props.theme.textColor,
     padding: '20px',


### PR DESCRIPTION
Currently the rows menu opens fixed, which is nice in the default state: 
<img width="1061" alt="Screenshot 2019-03-24 at 20 35 02" src="https://user-images.githubusercontent.com/6772156/54884901-a69e2400-4e76-11e9-8b1c-10eef607abfe.png">

However, once you scroll it actually appears lower the further you scroll (leading to it being outside of the viewport really fast):
<img width="1085" alt="Screenshot 2019-03-24 at 20 37 02" src="https://user-images.githubusercontent.com/6772156/54884902-a69e2400-4e76-11e9-9f90-fb9a90024dfb.png">

Moreover, if you open the menu at the bottom of the screen you can't actually see it anymore because it does not extend the screen to scroll.

Making it position:absolute resolves both of these issues. 

(Note, maybe you had deeper thoughts on making it position:fixed. If so, feel free to take over this PR and fix it another way :) ) 
