### PR TITLE
fix: use correct plugin name in slate inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - **ui**. Added Checkbox, Button and Textarea components for overlay
 - **plugin-image**. Added `onPaste` handler accepting jpg, png, bmp, gif, svg
 - **plugin-video**. Added video plugin
+- **core**. Added `name` prop to plugins
 
 ### Fixed
 

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -101,6 +101,7 @@ export const DocumentEditor: React.FunctionComponent<DocumentProps> = ({
           editable={editable}
           focused={focused}
           state={state}
+          name={document.plugin}
         />
       </div>
     </HotKeys>

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -20,6 +20,7 @@ export interface StatelessPlugin<Props extends Record<string, unknown> = {}> {
 export type StatelessPluginEditorProps<
   Props extends Record<string, unknown> = {}
 > = {
+  name?: string
   editable?: boolean
   focused?: boolean
 } & Props

--- a/packages/plugin-rows/src/editor.tsx
+++ b/packages/plugin-rows/src/editor.tsx
@@ -135,12 +135,16 @@ const Popup: React.FunctionComponent<{
   onClickOutside: () => void
   onClose: (pluginState: PluginState) => void
   plugins: Record<string, Plugin>
+  ownName?: string
 }> = props => {
   return (
     <OnClickOutside onClick={props.onClickOutside}>
       <AddMenuContainer>
         <AddMenu>
           {R.map(plugin => {
+            if (plugin === props.ownName) {
+              return null
+            }
             return (
               <Button
                 key={plugin}
@@ -191,6 +195,7 @@ export const RowsEditor = (
           onClickOutside={() => setPopup(undefined)}
           onClose={popup.onClose}
           plugins={getPlugins(store.state)}
+          ownName={props.name}
         />
       ) : null}
       {rows.items.map((row, index) => {
@@ -207,6 +212,7 @@ export const RowsEditor = (
                 onClickOutside={() => setPopup(undefined)}
                 onClose={popup.onClose}
                 plugins={getPlugins(store.state)}
+                ownName={props.name}
               />
             ) : null}
             <BottomFloatingButtonContainer>

--- a/packages/plugin-text/src/factory/editor.tsx
+++ b/packages/plugin-text/src/factory/editor.tsx
@@ -51,12 +51,14 @@ export const createTextEditor = (
     }
     // PLEASE DONT FIX THIS! Closure needed because on* isn't recreated so doesnt use current props
     const slateClosure = React.useRef<SlateClosure>({
+      name: props.name || 'text',
       plugins: plugins,
       insert: props.insert,
       focusPrevious: focusPrevious,
       focusNext: focusNext
     })
     slateClosure.current = {
+      name: props.name || 'text',
       plugins: plugins,
       insert: props.insert,
       focusPrevious: focusPrevious,
@@ -116,7 +118,7 @@ function createOnPaste(slateClosure: React.RefObject<SlateClosure>): EventHook {
       return
     }
 
-    const { plugins, insert } = slateClosure.current
+    const { plugins, insert, name } = slateClosure.current
     if (typeof insert !== 'function') {
       next()
       return
@@ -132,7 +134,7 @@ function createOnPaste(slateClosure: React.RefObject<SlateClosure>): EventHook {
           const nextSlateState = splitBlockAtSelection(editor)
 
           setTimeout(() => {
-            insert({ plugin: 'text', state: nextSlateState })
+            insert({ plugin: name, state: nextSlateState })
             insert({ plugin: key, state: result.state })
           })
           return
@@ -172,7 +174,7 @@ function createOnKeyDown(
           if (!slateClosure.current) return
           const { insert } = slateClosure.current
           if (typeof insert !== 'function') return
-          insert({ plugin: 'text', state: nextSlateState })
+          insert({ plugin: slateClosure.current.name, state: nextSlateState })
         })
         return
       }
@@ -251,6 +253,7 @@ export interface SlateEditorAdditionalProps {
 }
 
 interface SlateClosure extends SlateEditorAdditionalProps {
+  name: string
   focusPrevious: () => void
   focusNext: () => void
   plugins: Record<string, Plugin>

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -128,7 +128,8 @@ async function exec(): Promise<void> {
         '**demo**. Added containers to demo storybook. Initially, we have a "plain" container (equivalent to the previosly existing demo) and a "Serlo" container (mocking integration into [serlo.org](https://de.serlo.org). You can select your preferred container in the storybook\'s addon panel on the right.',
         '**ui**. Added Checkbox, Button and Textarea components for overlay',
         '**plugin-image**. Added `onPaste` handler accepting jpg, png, bmp, gif, svg',
-        '**plugin-video**. Added video plugin'
+        '**plugin-video**. Added video plugin',
+        '**core**. Added `name` prop to plugins'
       ],
       fixed: [
         '**core**. Handle focus in nested documents correctly',


### PR DESCRIPTION
## Added
 **core**. Added `name` prop to plugins

Used for:
 - correct plugin name in slate inserts
 - exclude rows plugin from add menu in rows plugin