### PR TITLE
fix: focus text plugin when its added

### DIFF
--- a/packages/plugin-text/src/factory/editor.tsx
+++ b/packages/plugin-text/src/factory/editor.tsx
@@ -87,7 +87,7 @@ export const createTextEditor = (
     React.useEffect(() => {
       if (!editor.current) return
       if (props.focused) {
-        editor.current.focus()
+        setTimeout(editor.current.focus())
       } else {
         editor.current.blur()
       }


### PR DESCRIPTION
When using multiple editors, newly created text plugins (e.g. on Enter) don't receive focus. This fix sets a timeout on the editor focus, which helped in my setup.

see #106 