### PR TITLE
some bug fixes for md-shortcuts and lists

### DIFF
--- a/packages/plugin-text/src/plugins/katex/editor.tsx
+++ b/packages/plugin-text/src/plugins/katex/editor.tsx
@@ -8,6 +8,7 @@ import { NodeEditorProps } from '../..'
 import { Dropdown, Option } from '../../toolbar/dropdown'
 import { Math } from './math.component'
 import { katexBlockNode, katexInlineNode } from './index'
+import { isList, orderedListNode, unorderedListNode } from '../list'
 
 const Wrapper = styled.div<{ inline: boolean }>(props => {
   return {
@@ -189,36 +190,39 @@ export const DefaultEditorComponent: React.FunctionComponent<
               latex
             </Option>
           </Dropdown>
-          <InlineCheckbox
-            label="Inline"
-            checked={inline}
-            onChange={checked => {
-              const newData = { formula: formulaState, inline: checked }
+          {!isList(orderedListNode)(editor) &&
+          !isList(unorderedListNode)(editor) ? (
+            <InlineCheckbox
+              label="Inline"
+              checked={inline}
+              onChange={checked => {
+                const newData = { formula: formulaState, inline: checked }
 
-              // remove old node, merge blocks if necessary
-              if (node.isLeafBlock()) {
-                const n = editor.value.document.getNextBlock(node.key)
-                editor.removeNodeByKey(node.key)
-                if (n) {
-                  editor.mergeNodeByKey(n.key)
+                // remove old node, merge blocks if necessary
+                if (node.isLeafBlock()) {
+                  const n = editor.value.document.getNextBlock(node.key)
+                  editor.removeNodeByKey(node.key)
+                  if (n) {
+                    editor.mergeNodeByKey(n.key)
+                  }
+                } else {
+                  editor.removeNodeByKey(node.key)
                 }
-              } else {
-                editor.removeNodeByKey(node.key)
-              }
 
-              if (checked) {
-                editor.insertInline({
-                  type: katexInlineNode,
-                  data: newData
-                })
-              } else {
-                editor.insertBlock({
-                  type: katexBlockNode,
-                  data: newData
-                })
-              }
-            }}
-          />
+                if (checked) {
+                  editor.insertInline({
+                    type: katexInlineNode,
+                    data: newData
+                  })
+                } else {
+                  editor.insertBlock({
+                    type: katexBlockNode,
+                    data: newData
+                  })
+                }
+              }}
+            />
+          ) : null}
         </HoveringOverlay>
       </Wrapper>
     )

--- a/packages/plugin-text/src/plugins/markdown.ts
+++ b/packages/plugin-text/src/plugins/markdown.ts
@@ -12,7 +12,7 @@ const handleMarkdown = (
   next: Function,
   name: string
 ) => {
-  if (/\d+\./.test(chars)) {
+  if (/^\d+\.$/.test(chars)) {
     if (isList(orderedListNode)(editor)) {
       return undefined
     }

--- a/packages/plugin-text/src/plugins/markdown.ts
+++ b/packages/plugin-text/src/plugins/markdown.ts
@@ -3,7 +3,6 @@ import { Editor } from 'slate'
 import { SlatePluginClosure } from '../factory/types'
 import { createBlockquote } from './blockquote'
 import { createSetHeading } from './headings'
-import { setParagraph } from './paragraph'
 import { TextPlugin } from '..'
 
 const handleMarkdown = (
@@ -68,32 +67,6 @@ const onSpace = (
   editor.moveFocusToStartOfNode(startBlock).delete()
 }
 
-const onBackspace = (event: KeyboardEvent, editor: Editor, next: Function) => {
-  const { value } = editor
-  const { selection } = value
-  if (selection.isExpanded) return next()
-  if (selection.start.offset !== 0) return next()
-
-  const { startBlock } = value
-  if (startBlock.type === 'paragraph') return next()
-
-  event.preventDefault()
-  setParagraph(editor)
-}
-
-const onEnter = (event: KeyboardEvent, editor: Editor, next: Function) => {
-  const { value } = editor
-  const { selection } = value
-  const { start, isExpanded } = selection
-  if (isExpanded) return next()
-
-  const { startBlock } = value
-  if (start.offset === 0 && startBlock.text.length === 0)
-    return onBackspace(event, editor, next)
-
-  return next()
-}
-
 export const markdownShortcuts = (
   pluginClosure: SlatePluginClosure
 ): TextPlugin => {
@@ -107,10 +80,6 @@ export const markdownShortcuts = (
       switch (e.key) {
         case ' ':
           return onSpace(e, editor, next, name)
-        case 'Backspace':
-          return onBackspace(e, editor, next)
-        case 'Enter':
-          return onEnter(e, editor, next)
         default:
           return next()
       }


### PR DESCRIPTION
fix: markdown recognizes a ordered list only at the beginning of the line
fix: markdown does not overwrite the behavior of enter and backspace
fix: Block formulas are not allowed within a list. Inline option is not displayed.