### PR TITLE
fix: make plugins traversable with arrow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 - **plugin-rows**. Adapt styles and controls implemented by schul-cloud, including drag&drop
 - **plugin-rows**. Add full color theming support
 
+### Fixed
+
+- **plugin-spoiler**, **plugin-solution**, **plugin-hint**, **plugin-equations**. Make children traversable
+
 ## [0.5.0](https://github.com/edtr-io/edtr-io/compare/v0.4.3..v0.5.0) - May 9, 2019
 
 ### Breaking Changes

--- a/packages/plugin-equations/src/index.ts
+++ b/packages/plugin-equations/src/index.ts
@@ -17,7 +17,17 @@ export const equationsPlugin: StatefulPlugin<typeof equationsState> = {
   state: equationsState,
   title: 'Gleichungen',
   description: 'Erzeuge einfach übersichtliche mathematische Gleichungen.',
-  icon: createIcon(faEquals)
+  icon: createIcon(faEquals),
+  getFocusableChildren(state) {
+    return state()
+      .steps()
+      .reduce(
+        (children, step) => {
+          return [...children, step().left, step().right, step().transform]
+        },
+        [] as { id: string }[]
+      )
+  }
 }
 
 export * from './editor'

--- a/packages/plugin-hint/src/index.ts
+++ b/packages/plugin-hint/src/index.ts
@@ -13,5 +13,8 @@ export const hintPlugin: StatefulPlugin<typeof hintState> = {
   state: hintState,
   title: 'Hinweis',
   description: 'Gib zusätzliche Tipps zur Aufgabe in dieser ausklappbaren Box.',
-  icon: createIcon(faLightbulb)
+  icon: createIcon(faLightbulb),
+  getFocusableChildren(state) {
+    return [state().content]
+  }
 }

--- a/packages/plugin-solution/src/index.ts
+++ b/packages/plugin-solution/src/index.ts
@@ -14,5 +14,8 @@ export const solutionPlugin: StatefulPlugin<typeof solutionState> = {
   icon: createIcon(faCheckSquare),
   title: 'Lösung',
   description:
-    'Gestalte in dieser ausklappbaren Box eine ausführliche Lösung zu deinen Aufgaben.'
+    'Gestalte in dieser ausklappbaren Box eine ausführliche Lösung zu deinen Aufgaben.',
+  getFocusableChildren(state) {
+    return [state().content]
+  }
 }

--- a/packages/plugin-spoiler/src/index.ts
+++ b/packages/plugin-spoiler/src/index.ts
@@ -14,7 +14,10 @@ export const spoilerPlugin: StatefulPlugin<typeof spoilerState> = {
   icon: createIcon(faCaretSquareDown),
   title: 'Spoiler',
   description:
-    'In diese ausklappbaren Box kannst du zum Beispiel Exkurse hinzufügen.'
+    'In diese ausklappbaren Box kannst du zum Beispiel Exkurse hinzufügen.',
+  getFocusableChildren(state) {
+    return [state().content]
+  }
 }
 
 export interface SpoilerTheme {

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -221,6 +221,9 @@ async function exec(): Promise<void> {
       changed: [
         '**plugin-rows**. Adapt styles and controls implemented by schul-cloud, including drag&drop',
         '**plugin-rows**. Add full color theming support'
+      ],
+      fixed: [
+        '**plugin-spoiler**, **plugin-solution**, **plugin-hint**, **plugin-equations**. Make children traversable'
       ]
     }
   ])


### PR DESCRIPTION
## Fixed

- **plugin-spoiler**, **plugin-solution**, **plugin-hint**, **plugin-equations**. Make children traversable

close #113 