### PR TITLE
touch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased](https://github.com/edtr-io/edtr-io/compare/v0.6.2..HEAD)
+
+### Fixed
+
+- **plugin-text**. Fix positioning of text controls on touch devices
+
 ## [0.6.2](https://github.com/edtr-io/edtr-io/compare/v0.6.1..v0.6.2) - June 19, 2019
 
 ### Added

--- a/packages/plugin-text/src/controls/index.tsx
+++ b/packages/plugin-text/src/controls/index.tsx
@@ -74,14 +74,20 @@ const ControlsSwitch: React.FunctionComponent<
   }
 }
 
-const TimeoutBottomToolbar = styled(BottomToolbar)<{ visible: boolean }>(
-  props => {
-    return {
-      opacity: props.visible ? 1 : 0,
-      transition: '500ms opacity ease-in-out'
-    }
+const TimeoutBottomToolbar = styled(BottomToolbar)<{
+  visible: boolean
+  isTouch: boolean
+}>(props => {
+  const touchStyles = props.isTouch
+    ? { bottom: 'unset', top: 0, transform: 'translate(-50%, 50%)' }
+    : {}
+
+  return {
+    opacity: props.visible ? 1 : 0,
+    transition: '500ms opacity ease-in-out',
+    ...touchStyles
   }
-)
+})
 
 let debounceTimeout: number
 export const Controls: React.FunctionComponent<ControlProps> = props => {
@@ -135,10 +141,19 @@ export const Controls: React.FunctionComponent<ControlProps> = props => {
     }
     return editor
   }, [])
+
+  function isTouchDevice(): boolean {
+    return (
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints > 0 ||
+      navigator.msMaxTouchPoints > 0
+    )
+  }
+
   return (
     <React.Fragment>
       {!selectionCollapsed && (
-        <HoveringOverlay position={'above'}>
+        <HoveringOverlay position={isTouchDevice() ? 'below' : 'above'}>
           <ControlsSwitch
             {...props}
             visibleControls={visibleControls}
@@ -149,6 +164,7 @@ export const Controls: React.FunctionComponent<ControlProps> = props => {
       )}
       {!props.readOnly && (
         <TimeoutBottomToolbar
+          isTouch={isTouchDevice()}
           visible={selectionCollapsed && bottomToolbarVisible}
         >
           {bottomToolbarVisible && (

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -258,6 +258,11 @@ async function exec(): Promise<void> {
         '**plugin-image**. Do not lose focus in PrimarySettings',
         '**plugin-image**. Display Placeholder on empty image'
       ]
+    },
+    {
+      fixed: [
+        '**plugin-text**. Fix positioning of text controls on touch devices'
+      ]
     }
   ])
 


### PR DESCRIPTION
Auf touch Geräten wird das text selection menu unterhalb des Textes angezeigt, um zu verhindern, dass sich diese mit dem nativen Textauswahlmenü überlagert. Das timeout menu am unteren Rand des Bildschirms wird stattdessen am oberen Rand gerendert, damit es nicht durch die Tastatur überlagert wird.

Es ist nicht möglich im Browser das Text-Selection Menu zu ändern oder zu erweitern.
Auch ist es nicht möglich im Browser einen Listener auf die Tastatur zu setzen.

