### PR TITLE
refactor highlight plugin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     '^react-dnd-test-backend$': 'react-dnd-test-backend/dist/cjs',
     '^react-dnd-test-utils$': 'react-dnd-test-utils/dist/cjs',
     '\\.(css|less|eot|svg|ttf|woff|woff2)$': '<rootDir>/jest.styleMock.js'
-  }
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(react-syntax-highlighter)/)']
 }

--- a/packages/plugins/highlight/package.json
+++ b/packages/plugins/highlight/package.json
@@ -18,8 +18,8 @@
     "@edtr-io/ui": "^0.12.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
-    "@types/react-syntax-highlighter": "^10.0.0",
-    "react-syntax-highlighter": "^10.0.0"
+    "@types/react-syntax-highlighter": "^11.0.0",
+    "react-syntax-highlighter": "^11.0.0"
   },
   "devDependencies": {
     "@edtr-io/core": "^0.12.0",

--- a/packages/plugins/highlight/src/editor.tsx
+++ b/packages/plugins/highlight/src/editor.tsx
@@ -3,13 +3,27 @@ import {
   EditorInput,
   PrimarySettings
 } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
-import { EditorTextarea } from '@edtr-io/renderer-ui'
-import { Icon, faQuestionCircle, styled } from '@edtr-io/ui'
+import { StatefulPlugin, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { Icon, faQuestionCircle, faCode, styled, createIcon } from '@edtr-io/ui'
 import * as React from 'react'
 
 import { highlightState } from '.'
-import { HighlightRenderer } from './renderer'
+import { HighlightRendererProps } from './renderer'
+
+const Textarea = styled.textarea({
+  height: '250px',
+  width: '100%',
+  margin: 'auto',
+  padding: '10px',
+  resize: 'none',
+  fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+  border: 'none',
+  outline: 'none',
+  boxShadow: '0 1px 1px 0 rgba(0,0,0,0.50)',
+  '&::-webkit-input-placeholder': {
+    color: 'rgba(0,0,0,0.5)'
+  }
+})
 
 const QuestionIcon = styled(Icon)({
   color: 'black',
@@ -23,71 +37,87 @@ const CheckboxContainer = styled.div({
   float: 'right'
 })
 
-// TODO: type and theming. maybe put in editor-ui?
-const HelpIcon: React.FunctionComponent = () => (
-  <a
-    href="https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD"
-    rel="noopener noreferrer"
-    target="_blank"
-    title="Available Languages"
-  >
-    <QuestionIcon icon={faQuestionCircle} />
-  </a>
-)
+export const createHighlightEditor = (config: HighlightPluginConfig) =>
+  function HighlightEditor(
+    props: StatefulPluginEditorProps<typeof highlightState>
+  ) {
+    const Renderer = config.renderer
 
-export const HighlightEditor = (
-  props: StatefulPluginEditorProps<typeof highlightState> & {
-    insert?: (el: { plugin: string }) => void
-  }
-) => {
-  const { state, focused, editable } = props
+    const { state, focused, editable } = props
 
-  const edit = focused && editable
-  const [throttledEdit, setEditThrotteled] = React.useState(edit)
-  if (edit != throttledEdit) {
-    if (!edit) {
-      setTimeout(() => {
-        setEditThrotteled(false)
-      }, 500)
-    } else {
-      setEditThrotteled(true)
+    const edit = focused && editable
+    const [throttledEdit, setEditThrotteled] = React.useState(edit)
+    if (edit != throttledEdit) {
+      if (!edit) {
+        setTimeout(() => {
+          setEditThrotteled(false)
+        }, 500)
+      } else {
+        setEditThrotteled(true)
+      }
     }
-  }
-  return throttledEdit || edit ? (
-    <React.Fragment>
-      <EditorTextarea
-        value={state.text.value}
-        name="text"
-        placeholder="Write some code here. Preview will be shown when you leave the area"
-        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-          state.text.set(e.target.value)
-        }}
-        ref={props.defaultFocusRef}
-      >
-        {state.text.value}
-      </EditorTextarea>
-      <PrimarySettings>
-        <EditorInput
-          label="Language:"
-          value={state.language.value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            state.language.set(e.target.value)
+    return throttledEdit || edit ? (
+      <React.Fragment>
+        <Textarea
+          value={state.text.value}
+          name="text"
+          placeholder="Write some code here. Preview will be shown when you leave the area"
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            state.text.set(e.target.value)
           }}
-          placeholder="enter Language"
-        />
-        <HelpIcon />
-        <CheckboxContainer>
-          <EditorCheckbox
-            label="Show Line Numbers"
-            onChange={() => {
-              state.lineNumbers.set(!state.lineNumbers.value)
+        >
+          {state.text.value}
+        </Textarea>
+        <PrimarySettings>
+          <EditorInput
+            list="available-languages"
+            label="Language:"
+            value={state.language.value}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              state.language.set(e.target.value)
             }}
-            checked={state.lineNumbers.value}
+            placeholder="enter Language"
           />
-        </CheckboxContainer>
-      </PrimarySettings>
-    </React.Fragment>
-  ) : (
-    <HighlightRenderer {...props} />
-  )
+          <datalist id="available-languages">
+            {['c', 'javascript', 'jsx', 'markup', 'java', 'python'].map(
+              (language, index) => {
+                return <option key={index} value={language} />
+              }
+            )}
+          </datalist>
+          <CheckboxContainer>
+            <EditorCheckbox
+              label="Show Line Numbers"
+              onChange={() => {
+                state.lineNumbers.set(!state.lineNumbers.value)
+              }}
+              checked={state.lineNumbers.value}
+            />
+          </CheckboxContainer>
+        </PrimarySettings>
+      </React.Fragment>
+    ) : (
+      <Renderer
+        language={state.language.value}
+        lineNumbers={state.lineNumbers.value}
+        code={state.text.value}
+      />
+    )
+  }
+
+export function createHighlightPlugin(
+  config: HighlightPluginConfig
+): StatefulPlugin<typeof highlightState> {
+  return {
+    Component: createHighlightEditor(config),
+    state: highlightState,
+    title: 'Code',
+    description:
+      'Schreibe Code und lasse ihn je nach Programmiersprache highlighten.',
+    icon: createIcon(faCode)
+  }
+}
+
+export interface HighlightPluginConfig {
+  renderer: React.ComponentType<HighlightRendererProps>
 }

--- a/packages/plugins/highlight/src/editor.tsx
+++ b/packages/plugins/highlight/src/editor.tsx
@@ -4,7 +4,7 @@ import {
   PrimarySettings
 } from '@edtr-io/editor-ui'
 import { StatefulPlugin, StatefulPluginEditorProps } from '@edtr-io/plugin'
-import { Icon, faQuestionCircle, faCode, styled, createIcon } from '@edtr-io/ui'
+import { faCode, styled, createIcon } from '@edtr-io/ui'
 import * as React from 'react'
 
 import { highlightState } from '.'
@@ -21,14 +21,6 @@ const Textarea = styled.textarea({
   outline: 'none',
   boxShadow: '0 1px 1px 0 rgba(0,0,0,0.50)',
   '&::-webkit-input-placeholder': {
-    color: 'rgba(0,0,0,0.5)'
-  }
-})
-
-const QuestionIcon = styled(Icon)({
-  color: 'black',
-  margin: '0 10px -3px 5px',
-  '&:hover': {
     color: 'rgba(0,0,0,0.5)'
   }
 })
@@ -61,7 +53,7 @@ export const createHighlightEditor = (config: HighlightPluginConfig) =>
         <Textarea
           value={state.text.value}
           name="text"
-          placeholder="Write some code here. Preview will be shown when you leave the area"
+          placeholder="Füge hier deinen Code ein. Verlasse den Bereich, um eine Vorschau zu sehen."
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             state.text.set(e.target.value)
           }}
@@ -87,7 +79,7 @@ export const createHighlightEditor = (config: HighlightPluginConfig) =>
           </datalist>
           <CheckboxContainer>
             <EditorCheckbox
-              label="Show Line Numbers"
+              label="Zeilennummern anzeigen"
               onChange={() => {
                 state.lineNumbers.set(!state.lineNumbers.value)
               }}

--- a/packages/plugins/highlight/src/index.ts
+++ b/packages/plugins/highlight/src/index.ts
@@ -1,7 +1,8 @@
-import { boolean, object, StatefulPlugin, string } from '@edtr-io/plugin'
+import { StatefulPlugin, string, boolean, object } from '@edtr-io/plugin'
 import { createIcon, faCode } from '@edtr-io/ui'
+import * as React from 'react'
 
-import { HighlightEditor } from './editor'
+import { createHighlightEditor } from './editor'
 
 export const highlightState = object({
   text: string(''),
@@ -9,11 +10,22 @@ export const highlightState = object({
   lineNumbers: boolean(false)
 })
 
-export const highlightPlugin: StatefulPlugin<typeof highlightState> = {
-  Component: HighlightEditor,
-  state: highlightState,
-  title: 'Code',
-  description:
-    'Schreibe Code und lasse ihn je nach Programmiersprache highlighten.',
-  icon: createIcon(faCode)
+import { HighlightRenderer, HighlightRendererProps } from './renderer'
+
+export const highlightPlugin : StatefulPlugin<typeof highlightState> =
+  createHighlightPlugin({ renderer: HighlightRenderer })
+
+export function createHighlightPlugin(config: HighlightPluginConfig) : StatefulPlugin<typeof highlightState> {
+  return {
+    Component: createHighlightEditor(config),
+    state: highlightState,
+    title: 'Code',
+    description:
+      'Schreibe Code und lasse ihn je nach Programmiersprache highlighten.',
+    icon: createIcon(faCode)
+  }
+}
+
+export interface HighlightPluginConfig {
+  renderer: React.ComponentType<HighlightRendererProps>
 }

--- a/packages/plugins/highlight/src/index.ts
+++ b/packages/plugins/highlight/src/index.ts
@@ -3,6 +3,7 @@ import { createIcon, faCode } from '@edtr-io/ui'
 import * as React from 'react'
 
 import { createHighlightEditor } from './editor'
+import { HighlightRenderer, HighlightRendererProps } from './renderer'
 
 export const highlightState = object({
   text: string(''),
@@ -10,12 +11,13 @@ export const highlightState = object({
   lineNumbers: boolean(false)
 })
 
-import { HighlightRenderer, HighlightRendererProps } from './renderer'
+export const highlightPlugin: StatefulPlugin<
+  typeof highlightState
+> = createHighlightPlugin({ renderer: HighlightRenderer })
 
-export const highlightPlugin : StatefulPlugin<typeof highlightState> =
-  createHighlightPlugin({ renderer: HighlightRenderer })
-
-export function createHighlightPlugin(config: HighlightPluginConfig) : StatefulPlugin<typeof highlightState> {
+export function createHighlightPlugin(
+  config: HighlightPluginConfig
+): StatefulPlugin<typeof highlightState> {
   return {
     Component: createHighlightEditor(config),
     state: highlightState,

--- a/packages/plugins/highlight/src/renderer.tsx
+++ b/packages/plugins/highlight/src/renderer.tsx
@@ -13,14 +13,13 @@ export function HighlightRenderer(props: HighlightRendererProps) {
         overflow: 'auto'
       }}
     >
-      {props.code ||
-      'Klicke hier und füg deinen Quellcode ein...'}
+      {props.code || 'Klicke hier und füg deinen Quellcode ein...'}
     </SyntaxHighlighter>
   )
 }
 
 export interface HighlightRendererProps {
-  code: string,
-  language: string,
+  code: string
+  language: string
   lineNumbers: boolean
 }

--- a/packages/plugins/highlight/src/renderer.tsx
+++ b/packages/plugins/highlight/src/renderer.tsx
@@ -1,19 +1,26 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
-import SyntaxHighlight from 'react-syntax-highlighter'
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
+// eslint-disable-next-line import/no-internal-modules
+import style from 'react-syntax-highlighter/dist/esm/styles/prism/coy'
 
-import { highlightState } from '.'
-
-export function HighlightRenderer({
-  state
-}: StatefulPluginEditorProps<typeof highlightState>) {
+export function HighlightRenderer(props: HighlightRendererProps) {
   return (
-    <SyntaxHighlight
-      language={state.language.value}
-      showLineNumbers={state.lineNumbers.value}
+    <SyntaxHighlighter
+      language={props.language}
+      showLineNumbers={props.lineNumbers}
+      style={style}
+      customStyle={{
+        overflow: 'auto'
+      }}
     >
-      {state.text.value ||
-        'Switch into edit mode then paste your sourcecode here...'}
-    </SyntaxHighlight>
+      {props.code ||
+      'Klicke hier und füg deinen Quellcode ein...'}
+    </SyntaxHighlighter>
   )
+}
+
+export interface HighlightRendererProps {
+  code: string,
+  language: string,
+  lineNumbers: boolean
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,10 +2835,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@^10.0.0":
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.2.1.tgz#b0f75c22cbe7d12104581648348d91d3cd7f13fa"
-  integrity sha512-M2BAOiiQ2KDkCiuhO1UxAsSNfrSegUfXL1MabRggOoqJoPpaoSuTxGF+TgLuAjMEVW8dJDtp7WpBjjRLMxWgrQ==
+"@types/react-syntax-highlighter@^11.0.0":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz#a2e3ff657d7c47813f80ca930f3d959c31ec51e3"
+  integrity sha512-iMNcixH8330f2dq0RY+VOXCP8JFehgmOhLOtnO85Ty+qu0fHXJNEqWx5VuFv8v0aEq0U/N9d/k1yvA+c6PEmPw==
   dependencies:
     "@types/react" "*"
 
@@ -11873,10 +11873,10 @@ react-sizeme@^2.6.7:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
-react-syntax-highlighter@^10.0.0:
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-10.3.5.tgz#3b3e2d1eba92fb7988c3b50d22d2c74ae0263fdd"
-  integrity sha512-KR4YE7Q91bHEhvIxuvs/J3tJWfxTyBAAMS4fcMOR9h0C6SoCZIr1OUkVamHOqHMDEck4tdS9gp0D/vlAyPLftA==
+react-syntax-highlighter@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz#4e3f376e752b20d2f54e4c55652fd663149e4029"
+  integrity sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "~9.13.0"


### PR DESCRIPTION
Refactor the highlight plugin to reduce bundlesize: The react-syntax-highlighter is now used as `PrismAsyncLight`. You can override it by importing `createHighlightPlugin` instead and passing a render component which accepts the following props:
```
interface HighlightRendererProps {
  code: string,
  language: string,
  lineNumbers: boolean
} 
```

TODO:
-  export highlightPlugin instead of `createHighlightPluginWithDefault`
- cleanup