### PR TITLE
Sprint 2019-08-24

### DIFF
--- a/.eslint-ci.config.js
+++ b/.eslint-ci.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    './.eslintrc.js',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking'
+  ],
+  parserOptions: {
+    project: ['tsconfig.json', 'tsconfig.eslint.json']
+  }
+}

--- a/.eslint-extended-ci.config.js
+++ b/.eslint-extended-ci.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: ['./.eslint-ci.config.js'],
+  plugins: ['import-order-alphabetical'],
+  rules: {
+    // eslint-plugin-import-order-alphabetical
+    'import-order-alphabetical/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'external', 'internal'],
+          ['parent', 'sibling', 'index']
+        ]
+      }
+    ]
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,15 +9,11 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:react/recommended',
     'prettier/@typescript-eslint',
     'prettier'
   ],
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: ['tsconfig.json', 'tsconfig.eslint.json']
-  },
   plugins: ['@typescript-eslint', 'import', 'react-hooks'],
   rules: {
     // eslint

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,7 @@ module.exports = function(api) {
                   '@edtr-io/core': '@edtr-io/core/src',
                   '@edtr-io/renderer': '@edtr-io/renderer/src',
                   '@edtr-io/renderer-ssr': '@edtr-io/renderer-ssr/src',
+                  '@edtr-io/store-devtools': '@edtr-io/store-devtools/src',
                   '@edtr-io/ui': '@edtr-io/ui/src',
                   '@edtr-io/editor-ui': '@edtr-io/editor-ui/src',
                   '@edtr-io/renderer-ui': '@edtr-io/renderer-ui/src',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild-demo": "yarn build",
     "build-demo": "lerna run --scope=@edtr-io/demo build",
     "format": "npm-run-all -c format:*",
-    "format:eslint": "yarn _eslint --fix",
+    "format:eslint": "yarn _eslint --config .eslint-ci.config.js --fix",
     "format:prettier": "yarn _prettier --write",
     "lint": "npm-run-all lint:*",
     "lint:eslint": "yarn _eslint",
@@ -24,7 +24,7 @@
     "deploy": "yarn _publish",
     "deploy:from-package": "yarn deploy from-package",
     "deploy:prerelease": "yarn lerna version --amend --no-push && yarn deploy:from-package --dist-tag next",
-    "_eslint": "eslint \"{{packages/*,scripts}/{{__fixtures__,__helpers__,__stories__,__tests-ssr__,__tests__,src}/**/*,*},*}.{js,jsx,ts,tsx}\"",
+    "_eslint": "eslint \"{{packages/*,scripts}/{{__fixtures__,__helpers__,__stories__,__tests-ssr__,__tests__,src}/**/*,*},*}.{js,jsx,ts,tsx}\" --config .eslint-extended-ci.config.js",
     "_publish": "lerna publish --message \"release %v\"",
     "_prettier": "prettier \"{{.circleci,docs,packages/*,scripts}/{{__fixtures__,__helpers__,__stories__,__tests-ssr__,__tests__,src}/**/*,*},*}.{js,jsx,ts,tsx,json,md,yaml,yml}\""
   },

--- a/packages/core/__helpers__/index.ts
+++ b/packages/core/__helpers__/index.ts
@@ -1,9 +1,16 @@
+import { applyMiddleware, compose, Middleware } from 'redux'
+
 import { plugins } from '../__fixtures__/plugins'
 import { Action, createStore } from '../src/store'
 
 export const TEST_SCOPE = 'test'
 export function setupStore() {
   let actions: Action[] = []
+  const testMiddleware: Middleware = () => next => action => {
+    actions.push(action)
+    return next(action)
+  }
+
   const store = createStore({
     instances: {
       [TEST_SCOPE]: {
@@ -11,7 +18,12 @@ export function setupStore() {
         defaultPlugin: 'text'
       }
     },
-    actions
+    createEnhancer: defaultEnhancer => {
+      return compose(
+        defaultEnhancer,
+        applyMiddleware(testMiddleware)
+      )
+    }
   }).store
 
   return {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,15 +17,12 @@
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "@types/react-redux": "^7.0.0",
-    "@types/remote-redux-devtools": "^0.5.0",
     "@types/shortid": "^0.0.29",
     "ramda": "^0.26.1",
     "react-hotkeys": "^2.0.0",
     "react-redux": "^7.0.0",
     "redux": "^4.0.0",
-    "redux-immutable-state-invariant": "^2.0.0",
     "redux-saga": "^1.0.0",
-    "remote-redux-devtools": "^0.5.0",
     "shortid": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/core/src/editor.tsx
+++ b/packages/core/src/editor.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import { configure, GlobalHotKeys } from 'react-hotkeys'
+import { StoreEnhancer } from 'redux'
 
 import { SubDocument } from './document'
 import {
@@ -33,7 +34,10 @@ const MAIN_SCOPE = 'main'
 let mountedProvider = false
 const mountedScopes: Record<string, boolean> = {}
 
-export function Editor<K extends string = string>(props: EditorProps<K>) {
+export function Editor<K extends string = string>({
+  createStoreEnhancer = defaultEnhancer => defaultEnhancer,
+  ...props
+}: EditorProps<K>) {
   const store = React.useMemo(() => {
     return createStore({
       instances: {
@@ -41,7 +45,8 @@ export function Editor<K extends string = string>(props: EditorProps<K>) {
           plugins: props.plugins,
           defaultPlugin: props.defaultPlugin
         }
-      }
+      },
+      createEnhancer: createStoreEnhancer
     }).store
     // We want to create the store only once
     // TODO: add effects that handle changes to plugins and defaultPlugin (by dispatching an action)
@@ -69,7 +74,11 @@ export function Editor<K extends string = string>(props: EditorProps<K>) {
 
 export const EditorProvider: React.FunctionComponent<{
   omitDragDropContext?: boolean
-}> = props => {
+  createStoreEnhancer?: EditorProps['createStoreEnhancer']
+}> = ({
+  createStoreEnhancer = defaultEnhancer => defaultEnhancer,
+  ...props
+}) => {
   React.useEffect(() => {
     if (mountedProvider) {
       // eslint-disable-next-line no-console
@@ -82,7 +91,8 @@ export const EditorProvider: React.FunctionComponent<{
   }, [])
   const store = React.useMemo(() => {
     return createStore({
-      instances: {}
+      instances: {},
+      createEnhancer: createStoreEnhancer
     }).store
     // We want to create the store only once
     // TODO: add effects that handle changes to plugins and defaultPlugin (by dispatching an action)
@@ -266,4 +276,7 @@ export interface EditorProps<K extends string = string> {
   theme?: CustomTheme
   onChange?: ChangeListener
   editable?: boolean
+  createStoreEnhancer?: (
+    defaultEnhancer: StoreEnhancer
+  ) => StoreEnhancer<unknown, unknown>
 }

--- a/packages/core/src/store/history/reducer.ts
+++ b/packages/core/src/store/history/reducer.ts
@@ -104,5 +104,7 @@ export function getRedoStack(state: ScopeState) {
 
 export const publicHistorySelectors = {
   getPendingChanges,
-  hasPendingChanges
+  hasPendingChanges,
+  getUndoStack,
+  getRedoStack
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -31,6 +31,7 @@
     "@edtr-io/plugin-text": "^0.8.3",
     "@edtr-io/plugin-video": "^0.8.3",
     "@edtr-io/renderer": "^0.8.3",
+    "@edtr-io/store-devtools": "^0.8.3",
     "@edtr-io/ui": "^0.8.3",
     "katex": "^0.10.0",
     "ramda": "^0.26.1",

--- a/packages/demo/src/container/plain.tsx
+++ b/packages/demo/src/container/plain.tsx
@@ -5,6 +5,7 @@ import {
   useEditorHistory
 } from '@edtr-io/core'
 import { Renderer, RendererProps } from '@edtr-io/renderer'
+import { createStoreDevtoolsEnhancer } from '@edtr-io/store-devtools'
 import * as React from 'react'
 
 import { useLogState } from '../hooks'
@@ -25,7 +26,11 @@ export function PlainEditorContainer(props: EditorProps) {
     [props.editable]
   )
 
-  return <Editor {...props}>{children}</Editor>
+  return (
+    <Editor {...props} createStoreEnhancer={createStoreDevtoolsEnhancer}>
+      {children}
+    </Editor>
+  )
 }
 
 function PlainEditorContainerInner(props: {

--- a/packages/demo/src/container/plain.tsx
+++ b/packages/demo/src/container/plain.tsx
@@ -11,7 +11,9 @@ import * as React from 'react'
 import { useLogState } from '../hooks'
 
 export function PlainRendererContainer(props: RendererProps) {
-  return <Renderer {...props} />
+  return (
+    <Renderer {...props} createStoreEnhancer={createStoreDevtoolsEnhancer} />
+  )
 }
 
 export function PlainEditorContainer(props: EditorProps) {

--- a/packages/demo/src/container/serlo-with-preview.tsx
+++ b/packages/demo/src/container/serlo-with-preview.tsx
@@ -1,4 +1,5 @@
 import { Document, EditorProps, EditorProvider } from '@edtr-io/core'
+import { createStoreDevtoolsEnhancer } from '@edtr-io/store-devtools'
 import * as React from 'react'
 
 import { useEditable } from '../hooks'
@@ -9,7 +10,7 @@ export function SerloWithPreviewEditorContainer(props: EditorProps) {
   const [editable, setEditable] = useEditable(props.editable)
 
   return (
-    <EditorProvider>
+    <EditorProvider createStoreEnhancer={createStoreDevtoolsEnhancer}>
       <div
         style={{
           position: 'fixed',

--- a/packages/demo/src/container/serlo.tsx
+++ b/packages/demo/src/container/serlo.tsx
@@ -8,7 +8,7 @@ import { useEditable, useLogState } from '../hooks'
 export function SerloRendererContainer(props: RendererProps) {
   return (
     <SerloContainerInner editable={false}>
-      <Renderer {...props} />
+      <Renderer {...props} createStoreEnhancer={createStoreDevtoolsEnhancer} />
     </SerloContainerInner>
   )
 }

--- a/packages/demo/src/container/serlo.tsx
+++ b/packages/demo/src/container/serlo.tsx
@@ -1,5 +1,6 @@
 import { Editor, EditorProps, useEditorHistory } from '@edtr-io/core'
 import { Renderer, RendererProps } from '@edtr-io/renderer'
+import { createStoreDevtoolsEnhancer } from '@edtr-io/store-devtools'
 import * as React from 'react'
 
 import { useEditable, useLogState } from '../hooks'
@@ -29,7 +30,11 @@ export function SerloEditorContainer(props: EditorProps) {
   )
 
   return (
-    <Editor {...props} editable={editable}>
+    <Editor
+      {...props}
+      editable={editable}
+      createStoreEnhancer={createStoreDevtoolsEnhancer}
+    >
       {children}
     </Editor>
   )

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -19,13 +19,15 @@
     "@edtr-io/core": "^0.8.3",
     "@edtr-io/ui": "^0.8.3",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "redux": "^4.0.0"
   },
   "peerDependencies": {
     "@edtr-io/core": "^0.8.0",
     "@edtr-io/ui": "^0.8.0",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "redux": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -8,18 +8,21 @@ import {
 } from '@edtr-io/core'
 import { CustomTheme, RootThemeProvider } from '@edtr-io/ui'
 import * as React from 'react'
+import { StoreEnhancer } from 'redux'
 
 export function Renderer<K extends string = string>({
+  createStoreEnhancer = defaultEnhancer => defaultEnhancer,
   theme = {},
   ...props
 }: RendererProps<K>) {
-  const { store } = createStore<string>({
+  const { store } = createStore<string, unknown, unknown>({
     instances: {
       main: {
         plugins: props.plugins,
         defaultPlugin: ''
       }
-    }
+    },
+    createEnhancer: createStoreEnhancer
   })
 
   store.dispatch(
@@ -48,4 +51,7 @@ export interface RendererProps<K extends string = string> {
     state?: unknown
   }
   theme?: CustomTheme
+  createStoreEnhancer?: (
+    defaultEnhancer: StoreEnhancer
+  ) => StoreEnhancer<unknown, unknown>
 }

--- a/packages/store-devtools/.npmignore
+++ b/packages/store-devtools/.npmignore
@@ -1,0 +1,2 @@
+# Rollup cache
+.rts2_cache*

--- a/packages/store-devtools/package.json
+++ b/packages/store-devtools/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@edtr-io/store-devtools",
+  "version": "0.8.3",
+  "license": "MIT",
+  "author": "edtr.io Consortium",
+  "main": "dist/index.js",
+  "module": "dist/core.esm.js",
+  "typings": "dist/index.d.ts",
+  "repository": "edtr-io/edtr-io",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "tsdx build --tsconfig tsconfig.prod.json"
+  },
+  "dependencies": {
+    "@types/redux-immutable-state-invariant": "^2.0.0",
+    "@types/remote-redux-devtools": "^0.5.0",
+    "redux-immutable-state-invariant": "^2.0.0",
+    "remote-redux-devtools": "^0.5.0"
+  },
+  "devDependencies": {
+    "redux": "^4.0.0"
+  },
+  "peerDependencies": {
+    "redux": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/store-devtools/src/index.ts
+++ b/packages/store-devtools/src/index.ts
@@ -1,0 +1,11 @@
+import { applyMiddleware, StoreEnhancer } from 'redux'
+import createImmutableStateInvariantMiddleware from 'redux-immutable-state-invariant'
+import { composeWithDevTools } from 'remote-redux-devtools'
+
+export function createStoreDevtoolsEnhancer(defaultEnhancer: StoreEnhancer) {
+  const composeEnhancers = composeWithDevTools({ realtime: true })
+  return composeEnhancers(
+    defaultEnhancer,
+    applyMiddleware(createImmutableStateInvariantMiddleware())
+  )
+}

--- a/packages/store-devtools/src/tsconfig.json
+++ b/packages/store-devtools/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "outDir": "../dist"
+  }
+}

--- a/packages/store-devtools/tsconfig.prod.json
+++ b/packages/store-devtools/tsconfig.prod.json
@@ -1,0 +1,8 @@
+{
+  "include": ["src"],
+  "extends": "../../tsconfig.prod",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "@edtr-io/core": ["core/src"],
       "@edtr-io/renderer": ["renderer/src"],
       "@edtr-io/renderer-ssr": ["renderer-ssr/src"],
+      "@edtr-io/store-devtools": ["store-devtools/src"],
       "@edtr-io/ui": ["ui/src"],
       "@edtr-io/editor-ui": ["ui-editor/src"],
       "@edtr-io/renderer-ui": ["ui-renderer/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,6 +2749,13 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/redux-immutable-state-invariant@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.1.tgz#8231007e9f370d2f5eb28b71c6a4d4b141973338"
+  integrity sha512-eosvcaKraeX8fyEKViFZ2vh3xSWF8teCSw+mEMjlwoN0Ai6ZAevczQr3YyZxZFfwH1LXUiV3aXcSAlsNKAnjNg==
+  dependencies:
+    redux "^3.6.0 || ^4.0.0"
+
 "@types/remote-redux-devtools@^0.5.0":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/remote-redux-devtools/-/remote-redux-devtools-0.5.3.tgz#04a1ed04566bfd0115be14dc933d5c47a6e59676"
@@ -12074,7 +12081,7 @@ redux-saga@^1.0.0:
   dependencies:
     "@redux-saga/core" "^1.0.3"
 
-"redux@>=0.10 <5", redux@^4.0.0, redux@^4.0.1:
+"redux@>=0.10 <5", "redux@^3.6.0 || ^4.0.0", redux@^4.0.0, redux@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==


### PR DESCRIPTION
## Changelog

### Breaking Changes

- **core**. `createStore` has a new required option `createStoreEnhancer`. Our high-level API (e.g. `<Editor />`, `<EditorProvider />` and `<Renderer />`) handle that change in a non-breaking way, though.

### Added

- **core**. Expose `getUndoStack` and `getRedoStack` selectors

### Changed

- **core**. Store no longer applies enhancers used for testing or development purposes. Instead,  `<Editor />`, `<EditorProvider />` and `<Renderer />` provide a new optional prop `createStoreEnhancer` that allows to extend the store enhancer used. Our previous enhancer for development is published as a new package `@edtr-io/store-devtools` (e.g. used in our demo).