### PR TITLE
fix loosing edits when clicking outside of plugin

### DIFF
--- a/packages/plugin-text/src/plugins/katex/editor.tsx
+++ b/packages/plugin-text/src/plugins/katex/editor.tsx
@@ -7,6 +7,7 @@ import {
   Overlay,
   styled
 } from '@edtr-io/editor-ui'
+import { EditorTextarea } from '@edtr-io/renderer-ui'
 import { canUseDOM } from 'exenv'
 import * as React from 'react'
 
@@ -107,9 +108,9 @@ export const DefaultEditorComponent: React.FunctionComponent<
 
   //Refs for positioning of hovering menu
   const mathQuillRef = React.createRef<typeof MathQuill>()
-  const latexInputRef = React.useRef<
+  const latexInputRef: React.MutableRefObject<
     HTMLInputElement | HTMLTextAreaElement | null
-  >()
+  > = React.useRef<HTMLInputElement | HTMLTextAreaElement>(null)
   const wrappedMathquillRef = Object.defineProperty({}, 'current', {
     // wrapper around Mathquill component
     get: () => {
@@ -221,7 +222,10 @@ export const DefaultEditorComponent: React.FunctionComponent<
             />
           ) : inline ? (
             <input
-              ref={ref => (latexInputRef.current = ref)}
+              ref={ref => {
+                if (!ref) return
+                latexInputRef.current = ref
+              }}
               type="text"
               value={formulaState}
               onChange={e => {
@@ -231,11 +235,13 @@ export const DefaultEditorComponent: React.FunctionComponent<
               autoFocus
             />
           ) : (
-            <textarea
-              style={{ width: '100%' }}
-              ref={ref => (latexInputRef.current = ref)}
-              value={formulaState}
+            <EditorTextarea
+              inputRef={ref => {
+                if (!ref) return
+                latexInputRef.current = ref
+              }}
               onChange={e => updateLatex(e.target.value)}
+              value={formulaState}
               onKeyDown={checkLeaveLatexInput}
               autoFocus
             />

--- a/packages/plugin-text/src/plugins/katex/index.tsx
+++ b/packages/plugin-text/src/plugins/katex/index.tsx
@@ -68,9 +68,16 @@ export const removeKatex = (editor: Editor) => {
 }
 
 export interface KatexPluginOptions {
-  EditorComponent?: React.ComponentType<NodeEditorProps & { name: string }>
+  EditorComponent?: React.ComponentType<
+    NodeEditorProps & { name: string; cache: EditCommitCache }
+  >
   RenderComponent?: React.ComponentType<NodeRendererProps>
   ControlsComponent?: React.ComponentType<NodeControlsProps>
+}
+
+export interface EditCommitCache {
+  key?: string
+  value?: string
 }
 
 export const createKatexPlugin = ({
@@ -79,6 +86,8 @@ export const createKatexPlugin = ({
 }: KatexPluginOptions = {}) => (
   pluginClosure: SlatePluginClosure
 ): TextPlugin => {
+  // this state is needed to hold uncommited edits of math editor
+  const editCommitCache = { key: undefined, value: undefined }
   return {
     deserialize(el, next) {
       switch (el.tagName.toLowerCase()) {
@@ -137,7 +146,14 @@ export const createKatexPlugin = ({
         (block.object === 'block' && block.type === katexBlockNode) ||
         (inline.object === 'inline' && inline.type === katexInlineNode)
       ) {
-        return <EditorComponent {...props} editor={editor} name={name} />
+        return (
+          <EditorComponent
+            {...props}
+            cache={editCommitCache}
+            editor={editor}
+            name={name}
+          />
+        )
       }
 
       return next()

--- a/packages/ui-editor/src/components/overlay-textarea.tsx
+++ b/packages/ui-editor/src/components/overlay-textarea.tsx
@@ -61,6 +61,10 @@ export class Textarea extends React.Component<TextareaProps> {
     }
   }
 
+  public getTextareaRef(): HTMLTextAreaElement | null {
+    return this.textarea.current
+  }
+
   public render() {
     const { label, ...props } = this.props
     return (

--- a/packages/ui-renderer/src/components/textarea.tsx
+++ b/packages/ui-renderer/src/components/textarea.tsx
@@ -21,12 +21,16 @@ const Textarea = styled(TextareaAutosize)({
   }
 })
 
+const StyledIgnoreKeys = styled(IgnoreKeys)({
+  width: '100%'
+})
+
 export function EditorTextarea(
   props: Omit<TextareaAutosizeProps, 'as' | 'ref'>
 ) {
   return (
-    <IgnoreKeys>
+    <StyledIgnoreKeys>
       <Textarea {...props} />
-    </IgnoreKeys>
+    </StyledIgnoreKeys>
   )
 }


### PR DESCRIPTION
Bug:

1. Edit any math field
2. click outside of plugin
3. Edit is lost :(

Problem:

EditorComponent is remounted when plugin is changed, unfortunately this destroys all local state

Fix:

Each slate katex plugins gets a cache (which persists remounts) that holds all uncomitted changes