### PR TITLE
fix color of editor-ui for edge and safari

### DIFF
--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -77,7 +77,7 @@ const Themed: React.FunctionComponent = () => {
     // Override shared theme for editor ui elements
     editor: {
       color: '#eeeeee',
-      background: 'rgb(51,51,51,0.95)',
+      background: 'rgba(51,51,51,0.95)',
       primary: {
         background: 'rgb(70, 155, 255)'
       }

--- a/packages/ui/src/editor-theme.ts
+++ b/packages/ui/src/editor-theme.ts
@@ -60,7 +60,7 @@ export const defaultEditorTheme: EditorTheme = {
     background: '#d9534f'
   },
   color: '#EEEEEE',
-  backgroundColor: 'rgb(51,51,51,0.95)'
+  backgroundColor: 'rgba(51,51,51,0.95)'
 }
 
 export interface ButtonTheme {


### PR DESCRIPTION
## Fixed
- **plugin-text**. Fix colors of editor ui in edge and safari

fixes #197 