### PR TITLE
fix: backwards compatibility with migratable

### DIFF
--- a/packages/renderer-ssr/__tests-ssr__/index.ts
+++ b/packages/renderer-ssr/__tests-ssr__/index.ts
@@ -134,8 +134,11 @@ describe('Renderer SSR', () => {
     const state: Document<typeof inputExerciseState> = {
       plugin: 'inputExercise',
       state: {
-        type: 'Text',
-        answers: []
+        __version__: 1,
+        value: {
+          type: 'Text',
+          answers: []
+        }
       }
     }
     render({


### PR DESCRIPTION
## Fixed
 - **plugin-input-exercise**. Use `migratable` in state for backwards compatibility with pre v0.11.2 state