### PR TITLE
heading always entering subcontrols

### DIFF
--- a/packages/plugin-text/src/controls/default.tsx
+++ b/packages/plugin-text/src/controls/default.tsx
@@ -17,7 +17,6 @@ import {
   toggleList,
   unorderedListNode
 } from '../plugins/list'
-import { setParagraph } from '../plugins/paragraph'
 import {
   isEmphasized,
   isStrong,
@@ -70,12 +69,7 @@ export const DefaultControls: React.FunctionComponent<
         name={name}
         active={!!getHeadingLevel(props.editor)}
         onClick={() => {
-          if (getHeadingLevel(props.editor)) {
-            setParagraph(props.editor)
-            props.onChange(editor)
-          } else {
-            props.switchControls(VisibleControls.Headings)
-          }
+          props.switchControls(VisibleControls.Headings)
         }}
         title="Überschriften"
       >


### PR DESCRIPTION
If you want to remove a heading, you click on the heading button to enter the subcontrols. You can remove it or change heading level.

This behaviour feels a bit more comfortable