### PR TITLE
Fix/serlo injections

### DIFF
--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -157,6 +157,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
             }
           }
         }}
+        allowChanges
       >
         <StyledDocument
           onMouseDown={handleFocus}

--- a/packages/plugin-serlo-injection/package.json
+++ b/packages/plugin-serlo-injection/package.json
@@ -16,6 +16,7 @@
     "@edtr-io/editor-ui": "^0.11.3",
     "@edtr-io/plugin": "^0.11.3",
     "@edtr-io/renderer-ui": "^0.11.3",
+    "iframe-resizer-react": "^1.0.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0"
   },

--- a/packages/plugin-serlo-injection/src/editor.tsx
+++ b/packages/plugin-serlo-injection/src/editor.tsx
@@ -54,7 +54,7 @@ export const SerloInjectionEditor = (
 
   React.useEffect(() => {
     setCache(props.state.value)
-  }, [props.focused])
+  }, [props.focused, props.state.value])
 
   if (!props.editable) {
     return <SerloInjectionRenderer src={createURL(props.state.value)} />

--- a/packages/plugin-serlo-injection/src/editor.tsx
+++ b/packages/plugin-serlo-injection/src/editor.tsx
@@ -5,9 +5,7 @@ import {
   PreviewOverlay,
   styled,
   Icon,
-  faNewspaper,
-  Button,
-  EditorButton
+  faNewspaper
 } from '@edtr-io/editor-ui'
 import { StatefulPluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
@@ -32,18 +30,6 @@ const PlaceholderWrapper = styled.div({
   textAlign: 'center'
 })
 
-const ButtonWrapper = styled.span({
-  float: 'right',
-  display: 'flex',
-  flexDirection: 'row',
-
-  justifyContent: 'flex-end'
-})
-
-const Clearfix = styled.div({
-  clear: 'both'
-})
-
 export const SerloInjectionEditor = (
   props: StatefulPluginEditorProps<typeof serloInjectionState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
@@ -53,7 +39,12 @@ export const SerloInjectionEditor = (
   const [preview, setPreview] = React.useState(false)
 
   React.useEffect(() => {
-    setCache(props.state.value)
+    const timeout = setTimeout(() => {
+      setCache(props.state.value)
+    }, 2000)
+    return () => {
+      clearTimeout(timeout)
+    }
   }, [props.focused, props.state.value])
 
   if (!props.editable) {
@@ -88,19 +79,9 @@ export const SerloInjectionEditor = (
             onChange={e => {
               props.state.set(e.target.value)
             }}
-            textfieldWidth="60%"
-            editorInputWidth="70%"
+            textfieldWidth="30%"
+            editorInputWidth="100%"
           />
-          <ButtonWrapper>
-            <EditorButton
-              onClick={() => {
-                setCache(props.state.value)
-              }}
-            >
-              Laden
-            </EditorButton>
-          </ButtonWrapper>
-          <Clearfix />
         </PrimarySettings>
       ) : null}
       {props.renderIntoExtendedSettings
@@ -114,16 +95,6 @@ export const SerloInjectionEditor = (
                   props.state.set(e.target.value)
                 }}
               />
-              <ButtonWrapper>
-                <Button
-                  onClick={() => {
-                    setCache(props.state.value)
-                  }}
-                >
-                  Laden
-                </Button>
-              </ButtonWrapper>
-              <Clearfix />
             </React.Fragment>
           )
         : null}

--- a/packages/plugin-serlo-injection/src/editor.tsx
+++ b/packages/plugin-serlo-injection/src/editor.tsx
@@ -2,7 +2,12 @@ import {
   PrimarySettings,
   EditorInput,
   OverlayInput,
-  PreviewOverlay
+  PreviewOverlay,
+  styled,
+  Icon,
+  faCode,
+  Button,
+  EditorButton
 } from '@edtr-io/editor-ui'
 import { StatefulPluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
@@ -21,17 +26,60 @@ const createURL = (id: string) => {
   return 'https://de.serlo.org/' + id + '?contentOnly&hideBreadcrumbs'
 }
 
+const PlaceholderWrapper = styled.div({
+  position: 'relative',
+  width: '100%',
+  textAlign: 'center'
+})
+
+const ButtonWrapper = styled.span({
+  float: 'right',
+  display: 'flex',
+  flexDirection: 'row',
+
+  justifyContent: 'flex-end'
+})
+
+const Clearfix = styled.div({
+  clear: 'both'
+})
+
 export const SerloInjectionEditor = (
   props: StatefulPluginEditorProps<typeof serloInjectionState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
   }
 ) => {
-  return props.editable ? (
+  const [cache, setCache] = React.useState(props.state.value)
+  const [preview, setPreview] = React.useState(false)
+
+  React.useEffect(() => {
+    setCache(props.state.value)
+  }, [props.focused])
+
+  if (!props.editable) {
+    return <SerloInjectionRenderer src={createURL(props.state.value)} />
+  }
+
+  return (
     <React.Fragment>
-      <PreviewOverlay focused={props.focused || false}>
-        <SerloInjectionRenderer src={createURL(props.state.value)} />
-      </PreviewOverlay>
-      {props.focused ? (
+      {cache ? (
+        <PreviewOverlay
+          focused={props.focused || false}
+          onChange={nextActive => {
+            setPreview(nextActive)
+            if (nextActive) {
+              setCache(props.state.value)
+            }
+          }}
+        >
+          <SerloInjectionRenderer src={createURL(cache)} />
+        </PreviewOverlay>
+      ) : (
+        <PlaceholderWrapper>
+          <Icon icon={faCode} size="5x"/>
+        </PlaceholderWrapper>
+      )}
+      {props.focused && !preview ? (
         <PrimarySettings>
           <EditorInput
             label="Serlo ID:"
@@ -40,25 +88,45 @@ export const SerloInjectionEditor = (
             onChange={e => {
               props.state.set(e.target.value)
             }}
-            textfieldWidth="30%"
-            editorInputWidth="100%"
+            textfieldWidth="60%"
+            editorInputWidth="70%"
           />
+          <ButtonWrapper>
+            <EditorButton
+              onClick={() => {
+                setCache(props.state.value)
+              }}
+            >
+              Laden
+            </EditorButton>
+          </ButtonWrapper>
+          <Clearfix />
         </PrimarySettings>
       ) : null}
       {props.renderIntoExtendedSettings
         ? props.renderIntoExtendedSettings(
-            <OverlayInput
-              label="Serlo ID:"
-              placeholder="123456"
-              value={props.state.value}
-              onChange={e => {
-                props.state.set(e.target.value)
-              }}
-            />
+            <React.Fragment>
+              <OverlayInput
+                label="Serlo ID:"
+                placeholder="123456"
+                value={props.state.value}
+                onChange={e => {
+                  props.state.set(e.target.value)
+                }}
+              />
+              <ButtonWrapper>
+                <Button
+                  onClick={() => {
+                    setCache(props.state.value)
+                  }}
+                >
+                  Laden
+                </Button>
+              </ButtonWrapper>
+              <Clearfix />
+            </React.Fragment>
           )
         : null}
     </React.Fragment>
-  ) : (
-    <SerloInjectionRenderer src={createURL(props.state.value)} />
   )
 }

--- a/packages/plugin-serlo-injection/src/editor.tsx
+++ b/packages/plugin-serlo-injection/src/editor.tsx
@@ -5,7 +5,7 @@ import {
   PreviewOverlay,
   styled,
   Icon,
-  faCode,
+  faNewspaper,
   Button,
   EditorButton
 } from '@edtr-io/editor-ui'
@@ -76,7 +76,7 @@ export const SerloInjectionEditor = (
         </PreviewOverlay>
       ) : (
         <PlaceholderWrapper>
-          <Icon icon={faCode} size="5x"/>
+          <Icon icon={faNewspaper} size="5x" />
         </PlaceholderWrapper>
       )}
       {props.focused && !preview ? (

--- a/packages/plugin-serlo-injection/src/index.ts
+++ b/packages/plugin-serlo-injection/src/index.ts
@@ -1,3 +1,4 @@
+import { createIcon, faNewspaper } from '@edtr-io/editor-ui'
 import { StatefulPlugin, string } from '@edtr-io/plugin'
 
 import { SerloInjectionEditor } from './editor'
@@ -10,5 +11,6 @@ export const serloInjectionPlugin: StatefulPlugin<
   Component: SerloInjectionEditor,
   state: serloInjectionState,
   title: 'Serlo Inhalt',
-  description: 'Binde einen Inhalt von serlo.org via ID ein'
+  description: 'Binde einen Inhalt von serlo.org via ID ein',
+  icon: createIcon(faNewspaper)
 }

--- a/packages/plugin-serlo-injection/src/renderer.tsx
+++ b/packages/plugin-serlo-injection/src/renderer.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react'
+import { styled } from '@edtr-io/renderer-ui'
 //@ts-ignore
 import IframeResizer from 'iframe-resizer-react'
-import { styled } from '@edtr-io/renderer-ui'
+import * as React from 'react'
 
 const Iframe = styled(IframeResizer)({
   width: '100%',
@@ -10,5 +10,9 @@ const Iframe = styled(IframeResizer)({
 })
 
 export const SerloInjectionRenderer = (props: { src: string }) => {
-  return <div><Iframe key={props.src} src={props.src}/></div>
+  return (
+    <div>
+      <Iframe key={props.src} src={props.src} />
+    </div>
+  )
 }

--- a/packages/plugin-serlo-injection/src/renderer.tsx
+++ b/packages/plugin-serlo-injection/src/renderer.tsx
@@ -1,35 +1,14 @@
-import { styled } from '@edtr-io/renderer-ui'
 import * as React from 'react'
+//@ts-ignore
+import IframeResizer from 'iframe-resizer-react'
+import { styled } from '@edtr-io/renderer-ui'
 
-const Iframe = styled.iframe({ width: '100%', border: 'none' })
+const Iframe = styled(IframeResizer)({
+  width: '100%',
+  border: '1px solid #ddd',
+  borderRadius: '2px'
+})
 
-export const SerloInjectionRenderer = (props: {
-  key?: string
-  ref?: React.RefObject<HTMLIFrameElement>
-  src: string
-}) => {
-  const iframeRef = React.useRef<HTMLIFrameElement>(null)
-
-  React.useEffect(() => {
-    // console.log('effect')
-    window.addEventListener('message', e => {
-      const { data } = e
-
-      // Content width in px
-      // console.log(data.contentWidth)
-      // Content height in px
-      // console.log(data.contentHeight)
-      // console.log(data.context)
-
-      // Context is always `serlo`
-      if (data.context !== 'serlo') {
-        return
-      }
-      // console.log(iframeRef.current)
-      if (iframeRef.current) {
-        iframeRef.current.setAttribute('height', data.contentHeight)
-      }
-    })
-  }, [])
-  return <Iframe key={props.src} ref={iframeRef} src={props.src} />
+export const SerloInjectionRenderer = (props: { src: string }) => {
+  return <div><Iframe key={props.src} src={props.src}/></div>
 }

--- a/packages/ui-editor/src/components/icon.tsx
+++ b/packages/ui-editor/src/components/icon.tsx
@@ -56,6 +56,7 @@ export { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt'
 export {
   faExternalLinkAlt
 } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt'
+export { faNewspaper } from '@fortawesome/free-solid-svg-icons/faNewspaper'
 
 export function createIcon(i: IconDefinition): React.FunctionComponent {
   return function I() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7668,6 +7668,19 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+iframe-resizer-react@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/iframe-resizer-react/-/iframe-resizer-react-1.0.0.tgz#503cdd61f937b4f424cea23b78947e81dd2cf3b8"
+  integrity sha512-bPOvgWBU0oqI9tgu8M9oZbNMS5UUpzpAD3iNAPFkAw5Cr+qzwJQVtlgGiykSc26SFzfXWTyZtWgu3If/A5wHgA==
+  dependencies:
+    iframe-resizer "^4.2.0"
+    warning "^4.0.3"
+
+iframe-resizer@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.2.2.tgz#4c28513ee8ec0c6f955aaeb71c0595d1f75f997c"
+  integrity sha512-YxTn4adCDVfMs84kyex1UyxxdXMKmMuUbgB4/WYq3jHiFz4XjtSQ8owBeSahAI9ui95ig6hlnwDkmPQh3+fmjA==
+
 ignore-walk@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.2.tgz#99d83a246c196ea5c93ef9315ad7b0819c35069b"


### PR DESCRIPTION
In accordance with https://github.com/serlo/serlo.org/pull/64 this use the [React integration](https://github.com/davidjbradshaw/iframe-resizer-react) of https://github.com/davidjbradshaw/iframe-resizer for the serlo injections.

For the resizing iframe to work, the client code from https://github.com/serlo/serlo.org/pull/64 needs to be deployed.

### Fixes
- **plugin-serlo-injection**. Auto resizing iframe when content or window height changes
- **plugin-serlo-injection**. Reduce content jumps by loading iframes only if requested.
- **core**. `HotKeys` component checks the correct state for deleting empty plugins.