### PR TITLE
fix focus movement through plugins

### DIFF
--- a/packages/abstract-plugin/src/index.ts
+++ b/packages/abstract-plugin/src/index.ts
@@ -81,6 +81,11 @@ export interface StatelessPluginEditorProps {
    * `true` if the plugin is currently focused
    */
   focused?: boolean
+
+  /**
+   * Ref to use for an input element. The element will receive focus, when the plugin is focused.
+   */
+  defaultFocusRef: React.RefObject<HTMLInputElement & HTMLTextAreaElement>
 }
 
 /**

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -39,6 +39,18 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
 
   const container = React.useRef<HTMLDivElement>(null)
 
+  const defaultFocusRef = React.useRef<HTMLInputElement & HTMLTextAreaElement>(null)
+
+  React.useEffect(() => {
+    if (focused) {
+      setTimeout(() => {
+        if (defaultFocusRef.current) {
+          defaultFocusRef.current.focus()
+        }
+      })
+    }
+  }, [focused])
+
   React.useEffect(() => {
     if (
       focused &&
@@ -169,6 +181,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
             {...pluginProps}
             editable
             focused={focused}
+            defaultFocusRef={defaultFocusRef}
             state={state}
             name={document.plugin}
           />

--- a/packages/core/src/document/editor.tsx
+++ b/packages/core/src/document/editor.tsx
@@ -39,7 +39,9 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
 
   const container = React.useRef<HTMLDivElement>(null)
 
-  const defaultFocusRef = React.useRef<HTMLInputElement & HTMLTextAreaElement>(null)
+  const defaultFocusRef = React.useRef<HTMLInputElement & HTMLTextAreaElement>(
+    null
+  )
 
   React.useEffect(() => {
     if (focused) {

--- a/packages/plugin-anchor/src/editor.tsx
+++ b/packages/plugin-anchor/src/editor.tsx
@@ -22,6 +22,7 @@ export const AnchorEditor = (
           onChange={e => {
             state.set(e.target.value)
           }}
+          ref={props.defaultFocusRef}
         />
       ) : null}
     </React.Fragment>

--- a/packages/plugin-geogebra/src/editor.tsx
+++ b/packages/plugin-geogebra/src/editor.tsx
@@ -24,6 +24,7 @@ export const GeogebraEditor = (
             }}
             textfieldWidth="70%"
             editorInputWidth="100%"
+            ref={props.defaultFocusRef}
           />
         </PrimarySettings>
       ) : null}

--- a/packages/plugin-highlight/src/editor.tsx
+++ b/packages/plugin-highlight/src/editor.tsx
@@ -64,6 +64,7 @@ export const HighlightEditor = (
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           state.text.set(e.target.value)
         }}
+        ref={props.defaultFocusRef}
       >
         {state.text.value}
       </EditorTextarea>

--- a/packages/plugin-image/src/editor.tsx
+++ b/packages/plugin-image/src/editor.tsx
@@ -125,6 +125,7 @@ function PrimaryControls(
         onChange={handleChange(props)('src')}
         editorInputWidth="70%"
         textfieldWidth="60%"
+        ref={props.defaultFocusRef}
       />
       <ButtonWrapper>
         {isTempFile(src.value) && src.value.failed ? (
@@ -181,6 +182,7 @@ function PrimaryControls(
               onChange={handleChange(props)('description')}
               editorInputWidth="90%"
               textfieldWidth="70%"
+              ref={props.defaultFocusRef}
             />
           </React.Fragment>
         )
@@ -194,6 +196,7 @@ function PrimaryControls(
               onChange={handleChange(props)('href')}
               editorInputWidth="90%"
               textfieldWidth="70%"
+              ref={props.defaultFocusRef}
             />
           </React.Fragment>
         )

--- a/packages/plugin-serlo-injection/src/editor.tsx
+++ b/packages/plugin-serlo-injection/src/editor.tsx
@@ -81,6 +81,7 @@ export const SerloInjectionEditor = (
             }}
             textfieldWidth="30%"
             editorInputWidth="100%"
+            ref={props.defaultFocusRef}
           />
         </PrimarySettings>
       ) : null}

--- a/packages/plugin-spoiler/src/editor.tsx
+++ b/packages/plugin-spoiler/src/editor.tsx
@@ -9,7 +9,8 @@ import { spoilerState, SpoilerTheme } from '.'
 export function SpoilerEditor({
   state,
   editable,
-  name
+  name,
+  defaultFocusRef
 }: StatefulPluginEditorProps<typeof spoilerState>) {
   const theme = usePluginTheme<SpoilerTheme>(name, () => {
     return {
@@ -36,6 +37,7 @@ export function SpoilerEditor({
           onChange={e => state.title.set(e.target.value)}
           value={state.title.value}
           placeholder="Titel eingeben"
+          ref={defaultFocusRef}
         />
       ) : (
         <React.Fragment>{state.title.value}</React.Fragment>

--- a/packages/plugin-spoiler/src/editor.tsx
+++ b/packages/plugin-spoiler/src/editor.tsx
@@ -43,7 +43,7 @@ export function SpoilerEditor({
         <React.Fragment>{state.title.value}</React.Fragment>
       )
     },
-    [editable, state.title]
+    [defaultFocusRef, editable, state.title]
   )
 
   return (

--- a/packages/plugin-table/src/editor.tsx
+++ b/packages/plugin-table/src/editor.tsx
@@ -28,6 +28,7 @@ export const createTableEditor = (config: TablePluginConfig) => {
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
                   state.set(e.target.value)
                 }}
+                ref={props.defaultFocusRef}
               >
                 {state.value}
               </EditorTextarea>

--- a/packages/plugin-video/src/editor.tsx
+++ b/packages/plugin-video/src/editor.tsx
@@ -48,6 +48,7 @@ export const VideoEditor = (
             }}
             textfieldWidth="80%"
             editorInputWidth="100%"
+            ref={props.defaultFocusRef}
           />
         </PrimarySettings>
       ) : null}

--- a/packages/ui-editor/src/components/editor-input.tsx
+++ b/packages/ui-editor/src/components/editor-input.tsx
@@ -50,7 +50,10 @@ const EditorInputInner = styled.input(
   }
 )
 
-const EditorInputRefForward: React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+const EditorInputRefForward: React.RefForwardingComponent<
+  HTMLInputElement,
+  InputProps
+> = (props, ref) => {
   const { label, ...rest } = props
   return (
     <EditorInputLabel width={rest.editorInputWidth}>

--- a/packages/ui-editor/src/components/editor-input.tsx
+++ b/packages/ui-editor/src/components/editor-input.tsx
@@ -50,27 +50,14 @@ const EditorInputInner = styled.input(
   }
 )
 
-export class EditorInput extends React.Component<InputProps> {
-  private input = React.createRef<HTMLInputElement>()
-
-  public focus() {
-    const input = this.input.current
-    if (input) {
-      input.focus()
-    }
-  }
-
-  public render() {
-    const { label, ...props } = this.props
-    return (
-      <EditorInputLabel width={props.editorInputWidth}>
-        {label}
-        <EditorInputInner
-          textWidth={props.textfieldWidth}
-          {...props}
-          ref={this.input}
-        />
-      </EditorInputLabel>
-    )
-  }
+const EditorInputRefForward: React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+  const { label, ...rest } = props
+  return (
+    <EditorInputLabel width={rest.editorInputWidth}>
+      {label}
+      <EditorInputInner textWidth={rest.textfieldWidth} {...rest} ref={ref} />
+    </EditorInputLabel>
+  )
 }
+
+export const EditorInput = React.forwardRef(EditorInputRefForward)

--- a/packages/ui-editor/src/components/overlay-input.tsx
+++ b/packages/ui-editor/src/components/overlay-input.tsx
@@ -52,12 +52,15 @@ const InputInner = styled.input((props: EditorThemeProps) => {
   }
 })
 
-const OverlayInputRefForward : React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+const OverlayInputRefForward: React.RefForwardingComponent<
+  HTMLInputElement,
+  InputProps
+> = (props, ref) => {
   const { label, ...rest } = props
   return (
     <InputLabel>
       <InputLabelInner>{label}</InputLabelInner>
-      <InputInner {...rest} ref={ref}/>
+      <InputInner {...rest} ref={ref} />
     </InputLabel>
   )
 }
@@ -78,7 +81,10 @@ const InlineInputInner = styled.input((props: EditorThemeProps) => {
   }
 })
 
-const InlineInputRefForward: React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+const InlineInputRefForward: React.RefForwardingComponent<
+  HTMLInputElement,
+  InputProps
+> = (props, ref) => {
   return <InlineInputInner {...props} ref={ref} />
 }
 export const InlineInput = React.forwardRef(InlineInputRefForward)

--- a/packages/ui-editor/src/components/overlay-input.tsx
+++ b/packages/ui-editor/src/components/overlay-input.tsx
@@ -51,7 +51,19 @@ const InputInner = styled.input((props: EditorThemeProps) => {
     }
   }
 })
-const InputInlineInner = styled.input((props: EditorThemeProps) => {
+
+const OverlayInputRefForward : React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+  const { label, ...rest } = props
+  return (
+    <InputLabel>
+      <InputLabelInner>{label}</InputLabelInner>
+      <InputInner {...rest} ref={ref}/>
+    </InputLabel>
+  )
+}
+export const OverlayInput = React.forwardRef(OverlayInputRefForward)
+
+const InlineInputInner = styled.input((props: EditorThemeProps) => {
   const theme = createOverlayTheme(props.theme)
 
   return {
@@ -66,57 +78,10 @@ const InputInlineInner = styled.input((props: EditorThemeProps) => {
   }
 })
 
-export class InlineInput extends React.Component<InputProps> {
-  private input = React.createRef<HTMLInputElement>()
-
-  public focus() {
-    const input = this.input.current
-    if (input) {
-      input.focus()
-    }
-  }
-
-  public render() {
-    return <InputInlineInner {...this.props} ref={this.input} />
-  }
+const InlineInputRefForward: React.RefForwardingComponent<HTMLInputElement, InputProps> = (props, ref) => {
+  return <InlineInputInner {...props} ref={ref} />
 }
-
-export class OverlayInput extends React.Component<InputProps> {
-  private input = React.createRef<HTMLInputElement>()
-
-  public focus() {
-    const input = this.input.current
-    if (input) {
-      input.focus()
-    }
-  }
-
-  public render() {
-    const { label, ...props } = this.props
-    return (
-      <InputLabel>
-        <InputLabelInner>{label}</InputLabelInner>
-        <InputInner {...props} ref={this.input} />
-      </InputLabel>
-    )
-  }
-}
-
-export class AutoFocusInput extends React.Component<InputProps> {
-  public render() {
-    return (
-      <OverlayInput
-        {...this.props}
-        //@ts-ignore FIXME
-        ref={(ref: Input | null) => {
-          if (ref) {
-            ref.focus()
-          }
-        }}
-      />
-    )
-  }
-}
+export const InlineInput = React.forwardRef(InlineInputRefForward)
 
 export interface InputProps
   extends React.DetailedHTMLProps<

--- a/packages/ui-renderer/src/components/textarea.tsx
+++ b/packages/ui-renderer/src/components/textarea.tsx
@@ -28,12 +28,37 @@ const StyledIgnoreKeys = styled(IgnoreKeys)({
   width: '100%'
 })
 
-export function EditorTextarea(
-  props: Omit<TextareaAutosizeProps, 'as' | 'ref'>
-) {
+const EditorTextareaRefForward: React.RefForwardingComponent<
+  HTMLTextAreaElement,
+  Omit<TextareaAutosizeProps, 'as' | 'ref'>
+> = (props, ref) => {
   return (
-    <StyledIgnoreKeys>
-      <Textarea {...props} />
+    <StyledIgnoreKeys except={['up', 'down']}>
+      <Textarea
+        {...props}
+        inputRef={ref || undefined}
+        onKeyDown={e => {
+          if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+            return
+          }
+          if (ref && typeof ref !== 'function' && ref.current) {
+            const { selectionStart, selectionEnd, value } = ref.current
+
+            if (selectionStart !== selectionEnd) {
+              return
+            }
+
+            if (e.key === 'ArrowUp' && selectionStart !== 0) {
+              e.stopPropagation()
+            }
+            if (e.key === 'ArrowDown' && selectionStart !== value.length) {
+              e.stopPropagation()
+            }
+          }
+        }}
+      />
     </StyledIgnoreKeys>
   )
 }
+
+export const EditorTextarea = React.forwardRef(EditorTextareaRefForward)


### PR DESCRIPTION
(for now building up on #229 because of the injection changes)

### Added
- **plugin**. Additional prop for plugins `defaultFocusRef`: Ref to use for an input element. The element will receive focus, when the plugin is focused

### Fixed
- **all**. Fixed focus movement with arrow keys.