### PR TITLE
improve undo behaviour

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -31,7 +31,7 @@ In a plugin embedding youtube videos the following `onPaste` function could be u
 ```typescript
 import { string, Plugin } from '@edtr-io/plugin'
 import * as React from 'react'
-import { YoutubeEditorComponent } from './editor' 
+import { YoutubeEditorComponent } from './editor'
 
 const youtubeState = string()
 const youtubePlugin: Plugin<typeof youtubeState> = {

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -29,8 +29,12 @@ The plugin should return void if it doesn't handle the pasted data or a object i
 In a plugin embedding youtube videos the following `onPaste` function could be used
 
 ```typescript
-const youtubeState = StateType.string()
-const youtubePlugin: StatefulPlugin<typeof youtubeState> = {
+import { string, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
+import { YoutubeEditorComponent } from './editor' 
+
+const youtubeState = string()
+const youtubePlugin: Plugin<typeof youtubeState> = {
   Component: YoutubeEditorComponent, // some React component displaying the youtube video
   state: youtubeState,
   onPaste(clipboardData: DataTransfer) {

--- a/docs/StateType.md
+++ b/docs/StateType.md
@@ -141,7 +141,6 @@ A `state` created with `object` exposes:
 Syntax highlighting example using `react-syntax-highlighter`
 
 ```typescript
-
 import { object, string, boolean, Plugin } from '@edtr-io/plugin'
 import * as React from 'react'
 import SyntaxHighlight from 'react-syntax-highlighter'
@@ -157,9 +156,7 @@ const highlighterPlugin: Plugin<typeof highlighterState> = {
       <div>
         <SyntaxHighlight
           language="javascript"
-          showLineNumbers={
-            state.showLineNumbers.value
-          }
+          showLineNumbers={state.showLineNumbers.value}
         >
           {state.text.value}
         </SyntaxHighlight>
@@ -210,19 +207,25 @@ const rowsPlugin: Plugin<typeof highlighterState> = {
   Component: ({ state }) => {
     return (
       <div>
-        {state.map(
-          (item, index) => {
-            return (
-              <div>
-                {item.render()}
-                <button onClick={() => state.insert(index + 1)}>Add</button>
-                <button onClick={() => state.remove(index)}>Remove</button>
-                { index > 0 ? <button onClick={() => state.move(index, index-1)}>Move up</button> : null }
-                { index + 1 < state.length ? <button onClick={() => state.move(index, index+1)}>Move down</button> : null}
-              </div>
-            )
-          }
-        )}
+        {state.map((item, index) => {
+          return (
+            <div>
+              {item.render()}
+              <button onClick={() => state.insert(index + 1)}>Add</button>
+              <button onClick={() => state.remove(index)}>Remove</button>
+              {index > 0 ? (
+                <button onClick={() => state.move(index, index - 1)}>
+                  Move up
+                </button>
+              ) : null}
+              {index + 1 < state.length ? (
+                <button onClick={() => state.move(index, index + 1)}>
+                  Move down
+                </button>
+              ) : null}
+            </div>
+          )
+        })}
       </div>
     )
   },

--- a/docs/StateType.md
+++ b/docs/StateType.md
@@ -7,31 +7,35 @@ Plugins use a common API for their state, which provides helper functions to the
 - `child` - represents an other plugin or sub document
 - `object` - composes other StateTypes to an object
 - `list` - represents a collection of an other StateType
+- `upload`
 
 ## Usage
 
-### `StateType.scalar`
+### `scalar`
 
 The `scalar` type handles single values of a consistent type. For standard types `string`, `boolean` and `number` the respective StateTypes can bes used and are functionally equivalent.
 
 #### API
 
-A `state` created with `StateType.scalar` exposes:
+A `state` created with `scalar` exposes:
 
-- `state()` - getter for the current stored value
+- `state.get()` - getter for the current stored value
 - `state.value` - the current stored value
 - `state.set(newValue: T | (currentValue: T) => T)` - function expecting a new value or an update function
 
 #### Example
 
 ```typescript
-const counterState = StateType.scalar(0) // equivalent to StateType.number(0)
+import { scalar, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
 
-const counterPlugin: StatefulPlugin<typeof counterState> = {
+const counterState = scalar(0) // equivalent to number(0)
+
+const counterPlugin: Plugin<typeof counterState> = {
   Component: ({ state }) => {
     return (
       <div>
-        {state.value /* equivalent to state() */}
+        {state.value}
         <button
           onClick={() => {
             state.set(value => value + 1)
@@ -46,30 +50,33 @@ const counterPlugin: StatefulPlugin<typeof counterState> = {
 }
 ```
 
-### `StateType.serializedScalar`
+### `serializedScalar`
 
-The `serializedScalar` adds a serializer logic around `StateType.scalar` and uses the same API. The plugin always receives the deserialized value, but a serialized value will be exported by the editor on serialization.
+The `serializedScalar` adds a serializer logic around `scalar` and uses the same API. The plugin always receives the deserialized value, but a serialized value will be exported by the editor on serialization.
 
 #### API
 
-See `StateType.scalar`
+See `scalar`
 
 #### Example
 
 ```typescript
+import { serializedScalar, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
+
 const serializer = {
   deserialize: JSON.parse,
   serialize: JSON.stringify
 }
-const jsonState = StateType.serializedScalar({ foo: 'bar' }, serializer)
+const jsonState = serializedScalar({ foo: 'bar' }, serializer)
 
-const jsonPlugin: StatefulPlugin<typeof jsonState> = {
+const jsonPlugin: Plugin<typeof jsonState> = {
   Component: ({ state }) => {
     return (
       <div>
         <input
           type="text"
-          value={state.value.foo /* equivalent to state().foo */}
+          value={state.value.foo}
           onChange={e =>
             state.set({
               foo: e.target.value
@@ -83,24 +90,27 @@ const jsonPlugin: StatefulPlugin<typeof jsonState> = {
 }
 ```
 
-### `StateType.child`
+### `child`
 
 The `child` type is used for including another plugin or whole sub document. Handling the state and actions of the sub document is done by the editor core automatically.
 
 #### API
 
-A `state` created with `StateType.child` exposes:
+A `state` created with `child` exposes:
 
-- `state()` - getter for the plugin id
+- `state.get()` - getter for the plugin id
 - `state.id` - the plugin id
 - `state.render()` - helper rendering the child in a `<Document>` component
 
 #### Example
 
 ```typescript
-const spoilerState = StateType.child()
+import { child, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
 
-const spoilerPlugin: StatefulPlugin<typeof spoilerState> = {
+const spoilerState = child()
+
+const spoilerPlugin: Plugin<typeof spoilerState> = {
   Component: ({ state }) => {
     const [hidden, setHidden] = React.useState(true)
     return (
@@ -116,15 +126,14 @@ const spoilerPlugin: StatefulPlugin<typeof spoilerState> = {
 }
 ```
 
-### `StateType.object`
+### `object`
 
 With the `object` type you can compose other StateTypes to an object.
 
 #### API
 
-A `state` created with `StateType.object` exposes:
+A `state` created with `object` exposes:
 
-- `state()` - getter for the object of the states
 - all the properties directly on `state`
 
 #### Example
@@ -132,23 +141,27 @@ A `state` created with `StateType.object` exposes:
 Syntax highlighting example using `react-syntax-highlighter`
 
 ```typescript
-const highlighterState = StateType.object({
-  text: StateType.string(`console.log('Hello World')`),
-  showLineNumbers: StateType.boolean(true)
+
+import { object, string, boolean, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
+import SyntaxHighlight from 'react-syntax-highlighter'
+
+const highlighterState = object({
+  text: string(`console.log('Hello World')`),
+  showLineNumbers: boolean(true)
 })
 
-const highlighterPlugin: StatefulPlugin<typeof highlighterState> = {
+const highlighterPlugin: Plugin<typeof highlighterState> = {
   Component: ({ state }) => {
     return (
       <div>
         <SyntaxHighlight
           language="javascript"
           showLineNumbers={
-            state.showLineNumbers
-              .value /* equivalent to state().showLineNumbers() */
+            state.showLineNumbers.value
           }
         >
-          {state.text.value /* equivalent to state().text() */}
+          {state.text.value}
         </SyntaxHighlight>
         <hr />
         <textarea
@@ -172,36 +185,40 @@ const highlighterPlugin: StatefulPlugin<typeof highlighterState> = {
 }
 ```
 
-### `StateType.list`
+### `list`
 
 With the `list` type you can handle a collection of other StateTypes
 
 #### API
 
-A `state` created with `StateType.list` exposes:
+A `state` created with `list` exposes:
 
-- `state()` - getter for the items state collection
-- `state.items` - the items state collection
+- `state` - the items as array
 - `state.insert(index?: number, initialItemState?: S)` - helper function for inserting a new item at the specified index (default: append as last item). Optionally pass an initial state for the item.
 - `state.remove(index: number)` - helper function for removing an item
+- `state.move(from: number, to: number)` - helper function for moving an item in the list to an other position
 
 #### Example
 
 ```typescript
-const rowsState = StateType.list(StateType.child(), 1)
+import { list, child, Plugin } from '@edtr-io/plugin'
+import * as React from 'react'
 
-const rowsPlugin: StatefulPlugin<typeof highlighterState> = {
+const rowsState = list(child(), 1)
+
+const rowsPlugin: Plugin<typeof highlighterState> = {
   Component: ({ state }) => {
     return (
       <div>
-        {state.items.map(
-          /* equivalent to state().map */
+        {state.map(
           (item, index) => {
             return (
               <div>
                 {item.render()}
                 <button onClick={() => state.insert(index + 1)}>Add</button>
                 <button onClick={() => state.remove(index)}>Remove</button>
+                { index > 0 ? <button onClick={() => state.move(index, index-1)}>Move up</button> : null }
+                { index + 1 < state.length ? <button onClick={() => state.move(index, index+1)}>Move down</button> : null}
               </div>
             )
           }
@@ -212,3 +229,15 @@ const rowsPlugin: StatefulPlugin<typeof highlighterState> = {
   state: rowsState
 }
 ```
+
+### `upload`
+
+With `upload` type you can handle asynchronous uploads of files, resolving to a url at the end
+
+#### API
+
+A `state` created with `upload` exposes:
+
+- `state.value` - the current value, either `string` or a pending file upload
+- `state.set` - set the value to a url
+- `state.upload` - upload a file

--- a/packages/plugins/anchor/src/editor.tsx
+++ b/packages/plugins/anchor/src/editor.tsx
@@ -7,9 +7,7 @@ import { anchorState } from '.'
 import { AnchorRenderer } from './renderer'
 
 const StyledIcon = styled(Icon)({ marginRight: '5px' })
-export const AnchorEditor = (
-  props: PluginEditorProps<typeof anchorState>
-) => {
+export const AnchorEditor = (props: PluginEditorProps<typeof anchorState>) => {
   const { editable, focused, state } = props
   return (
     <React.Fragment>

--- a/packages/plugins/anchor/src/editor.tsx
+++ b/packages/plugins/anchor/src/editor.tsx
@@ -1,5 +1,5 @@
 import { EditorInput } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { Icon, faLink, styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -8,7 +8,7 @@ import { AnchorRenderer } from './renderer'
 
 const StyledIcon = styled(Icon)({ marginRight: '5px' })
 export const AnchorEditor = (
-  props: StatefulPluginEditorProps<typeof anchorState>
+  props: PluginEditorProps<typeof anchorState>
 ) => {
   const { editable, focused, state } = props
   return (

--- a/packages/plugins/anchor/src/index.ts
+++ b/packages/plugins/anchor/src/index.ts
@@ -1,11 +1,11 @@
-import { StatefulPlugin, string } from '@edtr-io/plugin'
+import { Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faAnchor } from '@edtr-io/ui'
 
 import { AnchorEditor } from './editor'
 
 export const anchorState = string()
 
-export const anchorPlugin: StatefulPlugin<typeof anchorState> = {
+export const anchorPlugin: Plugin<typeof anchorState> = {
   Component: AnchorEditor,
   state: anchorState,
   title: 'Anker',

--- a/packages/plugins/anchor/src/renderer.tsx
+++ b/packages/plugins/anchor/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -9,7 +9,7 @@ const Anchor = styled.a({
 })
 
 export function AnchorRenderer(
-  props: StatefulPluginEditorProps<typeof anchorState>
+  props: PluginEditorProps<typeof anchorState>
 ) {
   return <Anchor id={props.state.value} />
 }

--- a/packages/plugins/anchor/src/renderer.tsx
+++ b/packages/plugins/anchor/src/renderer.tsx
@@ -8,8 +8,6 @@ const Anchor = styled.a({
   visibility: 'hidden'
 })
 
-export function AnchorRenderer(
-  props: PluginEditorProps<typeof anchorState>
-) {
+export function AnchorRenderer(props: PluginEditorProps<typeof anchorState>) {
   return <Anchor id={props.state.value} />
 }

--- a/packages/plugins/blockquote/src/index.ts
+++ b/packages/plugins/blockquote/src/index.ts
@@ -1,11 +1,11 @@
-import { child, StatefulPlugin } from '@edtr-io/plugin'
+import { child, Plugin } from '@edtr-io/plugin'
 import { createIcon, faQuoteRight } from '@edtr-io/ui'
 
 import { BlockquoteRenderer } from './renderer'
 
 export const blockquoteState = child()
 
-export const blockquotePlugin: StatefulPlugin<typeof blockquoteState> = {
+export const blockquotePlugin: Plugin<typeof blockquoteState> = {
   Component: BlockquoteRenderer,
   state: blockquoteState,
   title: 'Zitat',

--- a/packages/plugins/blockquote/src/renderer.tsx
+++ b/packages/plugins/blockquote/src/renderer.tsx
@@ -1,10 +1,10 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
 
 import { blockquoteState } from '.'
 
 export function BlockquoteRenderer(
-  props: StatefulPluginEditorProps<typeof blockquoteState>
+  props: PluginEditorProps<typeof blockquoteState>
 ) {
   return <blockquote>{props.state.render()}</blockquote>
 }

--- a/packages/plugins/equations/src/editor.tsx
+++ b/packages/plugins/equations/src/editor.tsx
@@ -4,7 +4,7 @@ import {
   useScopedSelector,
   useScopedStore
 } from '@edtr-io/core'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { focusNext, focusPrevious, getFocused, isEmpty } from '@edtr-io/store'
 import { Icon, faPlus, faTimes, styled } from '@edtr-io/ui'
 import * as R from 'ramda'
@@ -53,7 +53,7 @@ const AddButtonWrapper = styled.div({
 })
 
 export function EquationsEditor(
-  props: StatefulPluginEditorProps<typeof equationsState>
+  props: PluginEditorProps<typeof equationsState>
 ) {
   const store = useScopedStore()
   const focusedElement = useScopedSelector(getFocused())

--- a/packages/plugins/equations/src/index.ts
+++ b/packages/plugins/equations/src/index.ts
@@ -1,4 +1,4 @@
-import { child, list, object, StatefulPlugin } from '@edtr-io/plugin'
+import { child, list, object, Plugin } from '@edtr-io/plugin'
 import { createIcon, faEquals } from '@edtr-io/ui'
 
 import { EquationsEditor } from './editor'
@@ -13,7 +13,7 @@ export const equationsState = object({
   steps: list(StepProps)
 })
 
-export const equationsPlugin: StatefulPlugin<typeof equationsState> = {
+export const equationsPlugin: Plugin<typeof equationsState> = {
   Component: EquationsEditor,
   state: equationsState,
   title: 'Gleichungen',

--- a/packages/plugins/equations/src/renderer.tsx
+++ b/packages/plugins/equations/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StateTypeReturnType, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { StateTypeReturnType, PluginEditorProps } from '@edtr-io/plugin'
 import * as R from 'ramda'
 import * as React from 'react'
 
@@ -14,7 +14,7 @@ enum Phase {
 }
 
 export class EquationsRenderer extends React.Component<
-  StatefulPluginEditorProps<typeof equationsState>,
+  PluginEditorProps<typeof equationsState>,
   EquationsRendererState
 > {
   public state: EquationsState = {

--- a/packages/plugins/files/src/editor.tsx
+++ b/packages/plugins/files/src/editor.tsx
@@ -114,7 +114,7 @@ export function createFilesEditor(
 
           return null
         })}
-        {focused ? (
+        {focused || !state.length ? (
           <Upload
             onFiles={files => {
               files.forEach(file => {

--- a/packages/plugins/files/src/editor.tsx
+++ b/packages/plugins/files/src/editor.tsx
@@ -2,7 +2,7 @@ import { EditorButton } from '@edtr-io/editor-ui'
 import {
   isTempFile,
   usePendingFilesUploader,
-  StatefulPluginEditorProps,
+  PluginEditorProps,
   UploadHandler
 } from '@edtr-io/plugin'
 import { Icon, faRedoAlt, styled, EdtrIcon, edtrClose } from '@edtr-io/ui'
@@ -34,7 +34,7 @@ export const Center = styled.div({
 
 export function createFilesEditor(
   uploadHandler: UploadHandler<UploadedFile>
-): React.FunctionComponent<StatefulPluginEditorProps<typeof fileState>> {
+): React.FunctionComponent<PluginEditorProps<typeof fileState>> {
   return function FilesEditor(props) {
     const { focused, state } = props
 

--- a/packages/plugins/files/src/index.tsx
+++ b/packages/plugins/files/src/index.tsx
@@ -1,4 +1,4 @@
-import { list, StatefulPlugin, upload } from '@edtr-io/plugin'
+import { list, Plugin, upload } from '@edtr-io/plugin'
 import { createIcon, faFileAlt } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -16,7 +16,7 @@ export const fileState = list(
 
 export function createFilePlugin(
   config: UploadFileConfig
-): StatefulPlugin<typeof fileState> {
+): Plugin<typeof fileState> {
   const FilesEditor = createFilesEditor(config.upload)
   return {
     //eslint-disable-next-line react/display-name

--- a/packages/plugins/files/src/renderer.tsx
+++ b/packages/plugins/files/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { isTempFile, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { isTempFile, PluginEditorProps } from '@edtr-io/plugin'
 import {
   faFileArchive,
   faFileAudio,
@@ -51,7 +51,7 @@ export const FileRenderer: React.FunctionComponent<{
 }
 
 export function FilesRenderer(
-  props: StatefulPluginEditorProps<typeof fileState>
+  props: PluginEditorProps<typeof fileState>
 ) {
   return (
     <React.Fragment>

--- a/packages/plugins/files/src/renderer.tsx
+++ b/packages/plugins/files/src/renderer.tsx
@@ -50,9 +50,7 @@ export const FileRenderer: React.FunctionComponent<{
   )
 }
 
-export function FilesRenderer(
-  props: PluginEditorProps<typeof fileState>
-) {
+export function FilesRenderer(props: PluginEditorProps<typeof fileState>) {
   return (
     <React.Fragment>
       {props.state.map((file, i) => {

--- a/packages/plugins/geogebra/src/editor.tsx
+++ b/packages/plugins/geogebra/src/editor.tsx
@@ -1,12 +1,12 @@
 import { EditorInput, PrimarySettings } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
 
 import { geogebraState } from '.'
 import { GeogebraRenderer } from './renderer'
 
 export const GeogebraEditor = (
-  props: StatefulPluginEditorProps<typeof geogebraState>
+  props: PluginEditorProps<typeof geogebraState>
 ) => {
   const { focused, editable, state } = props
 

--- a/packages/plugins/geogebra/src/index.tsx
+++ b/packages/plugins/geogebra/src/index.tsx
@@ -1,4 +1,4 @@
-import { StatefulPlugin, string } from '@edtr-io/plugin'
+import { Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faCubes } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -6,7 +6,7 @@ import { GeogebraEditor } from './editor'
 import { GeogebraRenderer } from './renderer'
 
 export const geogebraState = string()
-export const geogebraPlugin: StatefulPlugin<typeof geogebraState> = {
+export const geogebraPlugin: Plugin<typeof geogebraState> = {
   //eslint-disable-next-line react/display-name
   Component: props =>
     props.editable ? (

--- a/packages/plugins/geogebra/src/renderer.tsx
+++ b/packages/plugins/geogebra/src/renderer.tsx
@@ -154,8 +154,6 @@ export function GeogebraRenderer({
   }
 }
 
-export type GeogebraRendererProps = PluginEditorProps<
-  typeof geogebraState
-> & {
+export type GeogebraRendererProps = PluginEditorProps<typeof geogebraState> & {
   disableCursorEvents?: boolean
 }

--- a/packages/plugins/geogebra/src/renderer.tsx
+++ b/packages/plugins/geogebra/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import axios from 'axios'
 import { debounce } from 'lodash'
@@ -154,7 +154,7 @@ export function GeogebraRenderer({
   }
 }
 
-export type GeogebraRendererProps = StatefulPluginEditorProps<
+export type GeogebraRendererProps = PluginEditorProps<
   typeof geogebraState
 > & {
   disableCursorEvents?: boolean

--- a/packages/plugins/highlight/src/editor.tsx
+++ b/packages/plugins/highlight/src/editor.tsx
@@ -3,6 +3,7 @@ import {
   EditorInput,
   PrimarySettings
 } from '@edtr-io/editor-ui'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { StatefulPlugin, StatefulPluginEditorProps } from '@edtr-io/plugin'
 import { faCode, styled, createIcon } from '@edtr-io/ui'
 import * as React from 'react'
@@ -31,7 +32,7 @@ const CheckboxContainer = styled.div({
 
 export const createHighlightEditor = (config: HighlightPluginConfig) =>
   function HighlightEditor(
-    props: StatefulPluginEditorProps<typeof highlightState>
+    props: PluginEditorProps <typeof highlightState>
   ) {
     const Renderer = config.renderer
 

--- a/packages/plugins/highlight/src/editor.tsx
+++ b/packages/plugins/highlight/src/editor.tsx
@@ -4,8 +4,7 @@ import {
   PrimarySettings
 } from '@edtr-io/editor-ui'
 import { PluginEditorProps } from '@edtr-io/plugin'
-import { StatefulPlugin, StatefulPluginEditorProps } from '@edtr-io/plugin'
-import { faCode, styled, createIcon } from '@edtr-io/ui'
+import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
 import { highlightState } from '.'
@@ -31,9 +30,7 @@ const CheckboxContainer = styled.div({
 })
 
 export const createHighlightEditor = (config: HighlightPluginConfig) =>
-  function HighlightEditor(
-    props: PluginEditorProps <typeof highlightState>
-  ) {
+  function HighlightEditor(props: PluginEditorProps<typeof highlightState>) {
     const Renderer = config.renderer
 
     const { state, focused, editable } = props
@@ -97,19 +94,6 @@ export const createHighlightEditor = (config: HighlightPluginConfig) =>
       />
     )
   }
-
-export function createHighlightPlugin(
-  config: HighlightPluginConfig
-): StatefulPlugin<typeof highlightState> {
-  return {
-    Component: createHighlightEditor(config),
-    state: highlightState,
-    title: 'Code',
-    description:
-      'Schreibe Code und lasse ihn je nach Programmiersprache highlighten.',
-    icon: createIcon(faCode)
-  }
-}
 
 export interface HighlightPluginConfig {
   renderer: React.ComponentType<HighlightRendererProps>

--- a/packages/plugins/highlight/src/index.ts
+++ b/packages/plugins/highlight/src/index.ts
@@ -1,4 +1,4 @@
-import { StatefulPlugin, string, boolean, object } from '@edtr-io/plugin'
+import { boolean, object, Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faCode } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -11,7 +11,7 @@ export const highlightState = object({
   lineNumbers: boolean(false)
 })
 
-export const highlightPlugin: StatefulPlugin<
+export const highlightPlugin: Plugin<typeof highlightState> = {
   typeof highlightState
 > = createHighlightPlugin({ renderer: HighlightRenderer })
 

--- a/packages/plugins/highlight/src/index.ts
+++ b/packages/plugins/highlight/src/index.ts
@@ -11,13 +11,13 @@ export const highlightState = object({
   lineNumbers: boolean(false)
 })
 
-export const highlightPlugin: Plugin<typeof highlightState> = {
+export const highlightPlugin: Plugin<
   typeof highlightState
 > = createHighlightPlugin({ renderer: HighlightRenderer })
 
 export function createHighlightPlugin(
   config: HighlightPluginConfig
-): StatefulPlugin<typeof highlightState> {
+): Plugin<typeof highlightState> {
   return {
     Component: createHighlightEditor(config),
     state: highlightState,

--- a/packages/plugins/hint/src/editor.tsx
+++ b/packages/plugins/hint/src/editor.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { ExpandableBox } from '@edtr-io/renderer-ui'
 import { ThemeProvider } from '@edtr-io/ui'
 import * as React from 'react'
@@ -17,7 +17,7 @@ const hintTheme = {
 export function HintEditor({
   state,
   editable
-}: StatefulPluginEditorProps<typeof hintState>) {
+}: PluginEditorProps<typeof hintState>) {
   const renderTitle = React.useCallback((collapsed: boolean) => {
     return (
       <React.Fragment>

--- a/packages/plugins/hint/src/index.ts
+++ b/packages/plugins/hint/src/index.ts
@@ -1,4 +1,4 @@
-import { child, object, StatefulPlugin, string } from '@edtr-io/plugin'
+import { child, object, Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faLightbulb } from '@edtr-io/ui'
 
 import { HintEditor } from './editor'
@@ -8,7 +8,7 @@ export const hintState = object({
   content: child('rows')
 })
 
-export const hintPlugin: StatefulPlugin<typeof hintState> = {
+export const hintPlugin: Plugin<typeof hintState> = {
   Component: HintEditor,
   state: hintState,
   title: 'Hinweis',

--- a/packages/plugins/image/src/editor.tsx
+++ b/packages/plugins/image/src/editor.tsx
@@ -112,7 +112,7 @@ function PrimaryControls(
             ? 'Wird hochgeladen...'
             : 'Upload fehlgeschlagen...'
         }
-        value={!isTempFile(src.value) ? src.value : undefined}
+        value={!isTempFile(src.value) ? src.value : ''}
         disabled={isTempFile(src.value) && !src.value.failed}
         onChange={handleChange(props)('src')}
         editorInputWidth="70%"

--- a/packages/plugins/image/src/editor.tsx
+++ b/packages/plugins/image/src/editor.tsx
@@ -8,7 +8,7 @@ import { EditorButton, EditorInput, PrimarySettings } from '@edtr-io/editor-ui'
 import {
   isTempFile,
   usePendingFileUploader,
-  StatefulPluginEditorProps
+  PluginEditorProps
 } from '@edtr-io/plugin'
 import {
   EditorThemeProps,
@@ -23,7 +23,7 @@ import { ImagePluginConfig, imageState } from '.'
 import { ImageRenderer } from './renderer'
 import { Upload } from './upload'
 
-type ImageProps = StatefulPluginEditorProps<typeof imageState> & {
+type ImageProps = PluginEditorProps<typeof imageState> & {
   renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
 }
 

--- a/packages/plugins/image/src/index.ts
+++ b/packages/plugins/image/src/index.ts
@@ -2,7 +2,7 @@ import {
   isTempFile,
   number,
   object,
-  StatefulPlugin,
+  Plugin,
   string,
   upload,
   UploadHandler,
@@ -22,7 +22,7 @@ export const imageState = object({
 })
 export const createImagePlugin = (
   config: ImagePluginConfig
-): StatefulPlugin<typeof imageState> => {
+): Plugin<typeof imageState> => {
   return {
     Component: createImageEditor(config),
     state: imageState,

--- a/packages/plugins/image/src/renderer.tsx
+++ b/packages/plugins/image/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { isTempFile, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { isTempFile, PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -88,7 +88,7 @@ export class ImageRenderer extends React.Component<ImageRendererProps> {
   }
 }
 
-export type ImageRendererProps = StatefulPluginEditorProps<
+export type ImageRendererProps = PluginEditorProps<
   typeof imageState
 > & {
   disableMouseEvents?: boolean

--- a/packages/plugins/image/src/renderer.tsx
+++ b/packages/plugins/image/src/renderer.tsx
@@ -88,8 +88,6 @@ export class ImageRenderer extends React.Component<ImageRendererProps> {
   }
 }
 
-export type ImageRendererProps = PluginEditorProps<
-  typeof imageState
-> & {
+export type ImageRendererProps = PluginEditorProps<typeof imageState> & {
   disableMouseEvents?: boolean
 }

--- a/packages/plugins/important-statement/src/index.ts
+++ b/packages/plugins/important-statement/src/index.ts
@@ -1,10 +1,10 @@
-import { child, StatefulPlugin } from '@edtr-io/plugin'
+import { child, Plugin } from '@edtr-io/plugin'
 
 import { ImportantStatementRenderer } from './renderer'
 
 export const importantStatementState = child()
 
-export const importantStatementPlugin: StatefulPlugin<
+export const importantStatementPlugin: Plugin<
   typeof importantStatementState
 > = {
   Component: ImportantStatementRenderer,

--- a/packages/plugins/important-statement/src/renderer.tsx
+++ b/packages/plugins/important-statement/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/renderer-ui'
 import * as React from 'react'
 
@@ -10,7 +10,7 @@ const Box = styled.div({
 })
 
 export function ImportantStatementRenderer(
-  props: StatefulPluginEditorProps<typeof importantStatementState>
+  props: PluginEditorProps<typeof importantStatementState>
 ) {
   return <Box>{props.state.render()}</Box>
 }

--- a/packages/plugins/input-exercise/src/editor.tsx
+++ b/packages/plugins/input-exercise/src/editor.tsx
@@ -5,7 +5,7 @@ import {
   styled,
   PreviewOverlay
 } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { getFocused } from '@edtr-io/store'
 import * as R from 'ramda'
 import * as React from 'react'
@@ -34,7 +34,7 @@ const AnswerTextfield = styled.input({
   width: '100%'
 })
 export function InputExerciseEditor(
-  props: StatefulPluginEditorProps<typeof inputExerciseState> & {
+  props: PluginEditorProps<typeof inputExerciseState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
   }
 ) {

--- a/packages/plugins/input-exercise/src/index.ts
+++ b/packages/plugins/input-exercise/src/index.ts
@@ -4,7 +4,7 @@ import {
   list,
   migratable,
   object,
-  StatefulPlugin,
+  Plugin,
   StateTypeSerializedType,
   string
 } from '@edtr-io/plugin'
@@ -69,7 +69,7 @@ export const inputExerciseState = migratable(stateV0)
     }
   })
 
-export const inputExercisePlugin: StatefulPlugin<typeof inputExerciseState> = {
+export const inputExercisePlugin: Plugin<typeof inputExerciseState> = {
   Component: InputExerciseEditor,
   state: inputExerciseState,
   title: 'Eingabefeld',

--- a/packages/plugins/input-exercise/src/renderer.tsx
+++ b/packages/plugins/input-exercise/src/renderer.tsx
@@ -1,6 +1,6 @@
 import { useScopedStore } from '@edtr-io/core'
 import { styled } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { Feedback, SubmitButton } from '@edtr-io/renderer-ui'
 import { isEmpty } from '@edtr-io/store'
 import { ThemeProps } from '@edtr-io/ui'
@@ -75,7 +75,7 @@ function matchesInput(field: { type: string; value: string }, input: string) {
 }
 
 export function InputExerciseRenderer(
-  props: StatefulPluginEditorProps<typeof inputExerciseState>
+  props: PluginEditorProps<typeof inputExerciseState>
 ) {
   const { state } = props
   const store = useScopedStore()

--- a/packages/plugins/multimedia-explanation/src/editor.tsx
+++ b/packages/plugins/multimedia-explanation/src/editor.tsx
@@ -1,6 +1,6 @@
 import { PluginToolbarButton, useScopedSelector } from '@edtr-io/core'
 import { Resizable } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import {
   hasFocusedDescendant,
   isFocused,
@@ -66,7 +66,7 @@ export function createMultimediaExplanationEditor(
   multimediaPlugins: PluginRegistry
 ) {
   return function MultimediaExplanationEditor(
-    props: StatefulPluginEditorProps<MultimediaExplanationState>
+    props: PluginEditorProps<MultimediaExplanationState>
   ) {
     function handleIllustratingChange(e: React.ChangeEvent<HTMLSelectElement>) {
       props.state.illustrating.set(e.target.value === 'illustrating')

--- a/packages/plugins/multimedia-explanation/src/index.ts
+++ b/packages/plugins/multimedia-explanation/src/index.ts
@@ -1,4 +1,4 @@
-import { boolean, child, number, object, StatefulPlugin } from '@edtr-io/plugin'
+import { boolean, child, number, object, Plugin } from '@edtr-io/plugin'
 import { createIcon, faPhotoVideo } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -18,7 +18,7 @@ export type MultimediaExplanationState = ReturnType<
 
 export const createMultimediaExplanationPlugin = (
   multimediaPlugins: PluginRegistry
-): StatefulPlugin<MultimediaExplanationState> => {
+): Plugin<MultimediaExplanationState> => {
   return {
     Component: createMultimediaExplanationEditor(multimediaPlugins),
     state: multimediaExplanationState(multimediaPlugins),

--- a/packages/plugins/rows/src/editor/index.tsx
+++ b/packages/plugins/rows/src/editor/index.tsx
@@ -1,5 +1,5 @@
 import { useScopedSelector } from '@edtr-io/core'
-import { StatefulPluginEditorProps, StateTypeReturnType } from '@edtr-io/plugin'
+import { PluginEditorProps, StateTypeReturnType } from '@edtr-io/plugin'
 import { getPlugins, isFocused } from '@edtr-io/store'
 import * as React from 'react'
 
@@ -50,7 +50,7 @@ function RowEditor({
 }
 
 export function RowsEditor(
-  props: StatefulPluginEditorProps<typeof rowsState> & {
+  props: PluginEditorProps<typeof rowsState> & {
     plugins?: PluginRegistry
   }
 ) {

--- a/packages/plugins/rows/src/editor/render.tsx
+++ b/packages/plugins/rows/src/editor/render.tsx
@@ -185,7 +185,7 @@ export function RowRenderer({
           dispatch(
             change({
               id: previousFocusId,
-              state: () => merged
+              state: { immediateState: () => merged }
             })
           )
           rows.remove(index)

--- a/packages/plugins/rows/src/editor/render.tsx
+++ b/packages/plugins/rows/src/editor/render.tsx
@@ -185,7 +185,7 @@ export function RowRenderer({
           dispatch(
             change({
               id: previousFocusId,
-              state: { immediateState: () => merged }
+              state: { immediate: () => merged }
             })
           )
           rows.remove(index)

--- a/packages/plugins/rows/src/editor/render.tsx
+++ b/packages/plugins/rows/src/editor/render.tsx
@@ -299,7 +299,7 @@ function createFakeDataTransfer(files: File[], text?: string) {
   class FakeDataTransfer extends DataTransfer {
     public dropEffect = 'all'
     public effectAllowed = 'all'
-    public readonly files = (files as unknown) as FileList
+    public files = (files as unknown) as FileList
     public readonly types = ['Files']
     public getData(type: string) {
       if (type.toLowerCase().startsWith('text')) {

--- a/packages/plugins/rows/src/editor/render.tsx
+++ b/packages/plugins/rows/src/editor/render.tsx
@@ -185,7 +185,7 @@ export function RowRenderer({
           dispatch(
             change({
               id: previousFocusId,
-              state: { immediate: () => merged }
+              state: { initial: () => merged }
             })
           )
           rows.remove(index)

--- a/packages/plugins/rows/src/index.tsx
+++ b/packages/plugins/rows/src/index.tsx
@@ -1,8 +1,8 @@
 import {
   child,
   list,
-  StatefulPlugin,
-  StatefulPluginEditorProps
+  Plugin,
+  PluginEditorProps
 } from '@edtr-io/plugin'
 import { createPluginTheme, PluginThemeFactory } from '@edtr-io/ui'
 import * as React from 'react'
@@ -15,7 +15,7 @@ export const rowsState = list(rowState, 1)
 
 function createRowsComponent(plugins?: PluginRegistry) {
   return function RowsComponent(
-    props: StatefulPluginEditorProps<typeof rowsState>
+    props: PluginEditorProps<typeof rowsState>
   ) {
     return props.editable ? (
       <RowsEditor {...props} plugins={plugins} />
@@ -27,7 +27,7 @@ function createRowsComponent(plugins?: PluginRegistry) {
 
 export function createRowsPlugin(
   plugins?: PluginRegistry
-): StatefulPlugin<typeof rowsState> {
+): Plugin<typeof rowsState> {
   return {
     Component: createRowsComponent(plugins),
     state: rowsState

--- a/packages/plugins/rows/src/index.tsx
+++ b/packages/plugins/rows/src/index.tsx
@@ -1,9 +1,4 @@
-import {
-  child,
-  list,
-  Plugin,
-  PluginEditorProps
-} from '@edtr-io/plugin'
+import { child, list, Plugin, PluginEditorProps } from '@edtr-io/plugin'
 import { createPluginTheme, PluginThemeFactory } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -14,9 +9,7 @@ export const rowState = child()
 export const rowsState = list(rowState, 1)
 
 function createRowsComponent(plugins?: PluginRegistry) {
-  return function RowsComponent(
-    props: PluginEditorProps<typeof rowsState>
-  ) {
+  return function RowsComponent(props: PluginEditorProps<typeof rowsState>) {
     return props.editable ? (
       <RowsEditor {...props} plugins={plugins} />
     ) : (

--- a/packages/plugins/rows/src/renderer.tsx
+++ b/packages/plugins/rows/src/renderer.tsx
@@ -8,9 +8,7 @@ const Row = styled.div({
   marginBottom: '25px'
 })
 
-export function RowsRenderer(
-  props: PluginEditorProps<typeof rowsState>
-) {
+export function RowsRenderer(props: PluginEditorProps<typeof rowsState>) {
   return (
     <React.Fragment>
       {props.state.map(row => {

--- a/packages/plugins/rows/src/renderer.tsx
+++ b/packages/plugins/rows/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -9,7 +9,7 @@ const Row = styled.div({
 })
 
 export function RowsRenderer(
-  props: StatefulPluginEditorProps<typeof rowsState>
+  props: PluginEditorProps<typeof rowsState>
 ) {
   return (
     <React.Fragment>

--- a/packages/plugins/sc-mc-exercise/src/answers-renderer.tsx
+++ b/packages/plugins/sc-mc-exercise/src/answers-renderer.tsx
@@ -1,4 +1,4 @@
-import { StateTypeReturnType, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { StateTypeReturnType, PluginEditorProps } from '@edtr-io/plugin'
 import { styled, FetchDimensions } from '@edtr-io/renderer-ui'
 import * as R from 'ramda'
 import * as React from 'react'
@@ -13,7 +13,7 @@ enum Phase {
 }
 
 export class ScMcAnswersRenderer extends React.Component<
-  StatefulPluginEditorProps<typeof scMcExerciseState> & {
+  PluginEditorProps<typeof scMcExerciseState> & {
     showAnswer: (
       answer: StateTypeReturnType<typeof AnswerProps>,
       index: number,

--- a/packages/plugins/sc-mc-exercise/src/choice-renderer.tsx
+++ b/packages/plugins/sc-mc-exercise/src/choice-renderer.tsx
@@ -1,5 +1,5 @@
 import { CheckElement } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -13,7 +13,7 @@ const CheckboxContainer = styled.div({
   fontWeight: 'bold'
 })
 export class ScMcExerciseChoiceRenderer extends React.Component<
-  StatefulPluginEditorProps<typeof scMcExerciseState> & ChoiceRendererProps
+  PluginEditorProps<typeof scMcExerciseState> & ChoiceRendererProps
 > {
   public render() {
     const {

--- a/packages/plugins/sc-mc-exercise/src/editor.tsx
+++ b/packages/plugins/sc-mc-exercise/src/editor.tsx
@@ -4,7 +4,7 @@ import {
   InteractiveAnswer,
   AddButton
 } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { getFocused, isEmpty as isEmptySelector } from '@edtr-io/store'
 import * as R from 'ramda'
 import * as React from 'react'
@@ -13,7 +13,7 @@ import { scMcExerciseState } from '.'
 import { ScMcExerciseRenderer } from './renderer'
 
 export function ScMcExerciseEditor(
-  props: StatefulPluginEditorProps<typeof scMcExerciseState> & {
+  props: PluginEditorProps<typeof scMcExerciseState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
   }
 ) {

--- a/packages/plugins/sc-mc-exercise/src/index.ts
+++ b/packages/plugins/sc-mc-exercise/src/index.ts
@@ -1,4 +1,4 @@
-import { boolean, child, list, object, StatefulPlugin } from '@edtr-io/plugin'
+import { boolean, child, list, object, Plugin } from '@edtr-io/plugin'
 import { createIcon, faDotCircle } from '@edtr-io/ui'
 
 import { ScMcExerciseEditor } from './editor'
@@ -15,7 +15,7 @@ export const scMcExerciseState = object({
   answers: list(AnswerProps)
 })
 
-export const scMcExercisePlugin: StatefulPlugin<typeof scMcExerciseState> = {
+export const scMcExercisePlugin: Plugin<typeof scMcExerciseState> = {
   Component: ScMcExerciseEditor,
   state: scMcExerciseState,
   icon: createIcon(faDotCircle),

--- a/packages/plugins/sc-mc-exercise/src/renderer-solution.tsx
+++ b/packages/plugins/sc-mc-exercise/src/renderer-solution.tsx
@@ -1,4 +1,4 @@
-import { StateTypeReturnType, StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { StateTypeReturnType, PluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
 
 import { AnswerProps, scMcExerciseState } from '.'
@@ -6,7 +6,7 @@ import { ScMcAnswersRenderer } from './answers-renderer'
 import { ScMcExerciseChoiceRenderer } from './choice-renderer'
 
 export class ScMcRendererSolution extends React.Component<
-  StatefulPluginEditorProps<typeof scMcExerciseState>
+  PluginEditorProps<typeof scMcExerciseState>
 > {
   public render() {
     return <ScMcAnswersRenderer {...this.props} showAnswer={this.showAnswer} />

--- a/packages/plugins/sc-mc-exercise/src/renderer.tsx
+++ b/packages/plugins/sc-mc-exercise/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -88,7 +88,7 @@ interface ScMcExerciseRendererState {
   mode: Mode
 }
 
-export type ScMcRendererProps = StatefulPluginEditorProps<
+export type ScMcRendererProps = PluginEditorProps<
   typeof scMcExerciseState
 > & {
   isEmpty: (id: string) => boolean

--- a/packages/plugins/sc-mc-exercise/src/renderer.tsx
+++ b/packages/plugins/sc-mc-exercise/src/renderer.tsx
@@ -88,8 +88,6 @@ interface ScMcExerciseRendererState {
   mode: Mode
 }
 
-export type ScMcRendererProps = PluginEditorProps<
-  typeof scMcExerciseState
-> & {
+export type ScMcRendererProps = PluginEditorProps<typeof scMcExerciseState> & {
   isEmpty: (id: string) => boolean
 }

--- a/packages/plugins/serlo-injection/src/editor.tsx
+++ b/packages/plugins/serlo-injection/src/editor.tsx
@@ -5,7 +5,7 @@ import {
   PreviewOverlay,
   styled
 } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { Icon, faNewspaper } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -30,7 +30,7 @@ const PlaceholderWrapper = styled.div({
 })
 
 export const SerloInjectionEditor = (
-  props: StatefulPluginEditorProps<typeof serloInjectionState> & {
+  props: PluginEditorProps<typeof serloInjectionState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
   }
 ) => {

--- a/packages/plugins/serlo-injection/src/index.ts
+++ b/packages/plugins/serlo-injection/src/index.ts
@@ -5,9 +5,7 @@ import { SerloInjectionEditor } from './editor'
 
 export const serloInjectionState = string()
 
-export const serloInjectionPlugin: Plugin<
-  typeof serloInjectionState
-> = {
+export const serloInjectionPlugin: Plugin<typeof serloInjectionState> = {
   Component: SerloInjectionEditor,
   state: serloInjectionState,
   title: 'Serlo Inhalt',

--- a/packages/plugins/serlo-injection/src/index.ts
+++ b/packages/plugins/serlo-injection/src/index.ts
@@ -1,11 +1,11 @@
-import { StatefulPlugin, string } from '@edtr-io/plugin'
+import { Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faNewspaper } from '@edtr-io/ui'
 
 import { SerloInjectionEditor } from './editor'
 
 export const serloInjectionState = string()
 
-export const serloInjectionPlugin: StatefulPlugin<
+export const serloInjectionPlugin: Plugin<
   typeof serloInjectionState
 > = {
   Component: SerloInjectionEditor,

--- a/packages/plugins/solution/src/editor.tsx
+++ b/packages/plugins/solution/src/editor.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { ExpandableBox } from '@edtr-io/renderer-ui'
 import { ThemeProvider } from '@edtr-io/ui'
 import * as React from 'react'
@@ -17,7 +17,7 @@ const solutionTheme = {
 export function SolutionEditor({
   state,
   editable
-}: StatefulPluginEditorProps<typeof solutionState>) {
+}: PluginEditorProps<typeof solutionState>) {
   const renderTitle = React.useCallback((collapsed: boolean) => {
     return (
       <React.Fragment>

--- a/packages/plugins/solution/src/index.ts
+++ b/packages/plugins/solution/src/index.ts
@@ -1,4 +1,4 @@
-import { child, object, StatefulPlugin, string } from '@edtr-io/plugin'
+import { child, object, Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faCheckSquare } from '@edtr-io/ui'
 
 import { SolutionEditor } from './editor'
@@ -8,7 +8,7 @@ export const solutionState = object({
   content: child('rows')
 })
 
-export const solutionPlugin: StatefulPlugin<typeof solutionState> = {
+export const solutionPlugin: Plugin<typeof solutionState> = {
   Component: SolutionEditor,
   state: solutionState,
   icon: createIcon(faCheckSquare),

--- a/packages/plugins/spoiler/src/editor.tsx
+++ b/packages/plugins/spoiler/src/editor.tsx
@@ -1,5 +1,5 @@
 import { EditorInput } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { ExpandableBox } from '@edtr-io/renderer-ui'
 import { ThemeProvider, usePluginTheme } from '@edtr-io/ui'
 import * as React from 'react'
@@ -11,7 +11,7 @@ export function SpoilerEditor({
   editable,
   name,
   defaultFocusRef
-}: StatefulPluginEditorProps<typeof spoilerState>) {
+}: PluginEditorProps<typeof spoilerState>) {
   const theme = usePluginTheme<SpoilerTheme>(name, () => {
     return {
       color: '#f5f5f5'

--- a/packages/plugins/spoiler/src/index.ts
+++ b/packages/plugins/spoiler/src/index.ts
@@ -1,4 +1,4 @@
-import { child, object, StatefulPlugin, string } from '@edtr-io/plugin'
+import { child, object, Plugin, string } from '@edtr-io/plugin'
 import { createIcon, faCaretSquareDown } from '@edtr-io/ui'
 
 import { SpoilerEditor } from './editor'
@@ -8,7 +8,7 @@ export const spoilerState = object({
   content: child('rows')
 })
 
-export const spoilerPlugin: StatefulPlugin<typeof spoilerState> = {
+export const spoilerPlugin: Plugin<typeof spoilerState> = {
   Component: SpoilerEditor,
   state: spoilerState,
   icon: createIcon(faCaretSquareDown),

--- a/packages/plugins/table/src/editor.tsx
+++ b/packages/plugins/table/src/editor.tsx
@@ -12,9 +12,7 @@ const Form = styled.form({
 
 export const createTableEditor = (config: TablePluginConfig) => {
   const TableRenderer = createTableRenderer(config)
-  return function TableEditor(
-    props: PluginEditorProps<typeof tableState>
-  ) {
+  return function TableEditor(props: PluginEditorProps<typeof tableState>) {
     const { focused, state } = props
     return (
       <div>

--- a/packages/plugins/table/src/editor.tsx
+++ b/packages/plugins/table/src/editor.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { EditorTextarea } from '@edtr-io/renderer-ui'
 import { styled } from '@edtr-io/ui'
 import * as React from 'react'
@@ -13,7 +13,7 @@ const Form = styled.form({
 export const createTableEditor = (config: TablePluginConfig) => {
   const TableRenderer = createTableRenderer(config)
   return function TableEditor(
-    props: StatefulPluginEditorProps<typeof tableState>
+    props: PluginEditorProps<typeof tableState>
   ) {
     const { focused, state } = props
     return (

--- a/packages/plugins/table/src/index.tsx
+++ b/packages/plugins/table/src/index.tsx
@@ -1,4 +1,4 @@
-import { StatefulPlugin, string } from '@edtr-io/plugin'
+import { Plugin, string } from '@edtr-io/plugin'
 import * as React from 'react'
 import ReactMarkdown from 'react-markdown'
 
@@ -8,7 +8,7 @@ export const tableState = string()
 
 export function createTablePlugin(
   config: TablePluginConfig
-): StatefulPlugin<typeof tableState> {
+): Plugin<typeof tableState> {
   return {
     Component: createTableEditor(config),
     state: tableState,

--- a/packages/plugins/table/src/renderer.tsx
+++ b/packages/plugins/table/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { Icon, faTable, styled } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -26,7 +26,7 @@ const StyledIcon = styled(Icon)({ marginRight: '5px' })
 
 export function createTableRenderer(config: TablePluginConfig) {
   return function TableRenderer(
-    props: StatefulPluginEditorProps<typeof tableState>
+    props: PluginEditorProps<typeof tableState>
   ) {
     const { editable, state } = props
 

--- a/packages/plugins/table/src/renderer.tsx
+++ b/packages/plugins/table/src/renderer.tsx
@@ -25,9 +25,7 @@ const TableContainer = styled.div({
 const StyledIcon = styled(Icon)({ marginRight: '5px' })
 
 export function createTableRenderer(config: TablePluginConfig) {
-  return function TableRenderer(
-    props: PluginEditorProps<typeof tableState>
-  ) {
+  return function TableRenderer(props: PluginEditorProps<typeof tableState>) {
     const { editable, state } = props
 
     const renderedMarkdown = config.renderMarkdown(state.value)

--- a/packages/plugins/text/src/factory/editor.tsx
+++ b/packages/plugins/text/src/factory/editor.tsx
@@ -1,5 +1,5 @@
 import { useScopedDispatch, useScopedSelector } from '@edtr-io/core'
-import { StatefulPluginEditorProps, Plugin } from '@edtr-io/plugin'
+import { PluginEditorProps, Plugin } from '@edtr-io/plugin'
 import {
   focusNext as focusNextActionCreator,
   focusPrevious as focusPreviousActionCreator,
@@ -526,7 +526,7 @@ function createDocumentFromNodes(nodes: Node[]) {
   }
 }
 
-export type SlateEditorProps = StatefulPluginEditorProps<typeof textState> &
+export type SlateEditorProps = PluginEditorProps<typeof textState> &
   SlateEditorAdditionalProps
 
 export interface SlateEditorAdditionalProps {

--- a/packages/plugins/text/src/factory/index.tsx
+++ b/packages/plugins/text/src/factory/index.tsx
@@ -1,4 +1,4 @@
-import { scalar, StatefulPlugin } from '@edtr-io/plugin'
+import { scalar, Plugin } from '@edtr-io/plugin'
 import { createIcon, faParagraph } from '@edtr-io/ui'
 import { Value, ValueJSON } from 'slate'
 
@@ -10,7 +10,7 @@ export const textState = scalar<ValueJSON>(emptyDocument)
 
 export const createTextPlugin = (
   options: TextPluginOptions
-): StatefulPlugin<typeof textState, SlateEditorAdditionalProps> => {
+): Plugin<typeof textState, SlateEditorAdditionalProps> => {
   return {
     Component: createTextEditor(options),
     state: textState,

--- a/packages/plugins/video/src/editor.tsx
+++ b/packages/plugins/video/src/editor.tsx
@@ -1,13 +1,13 @@
 import { OverlayInput } from '@edtr-io/core'
 import { EditorInput, PrimarySettings } from '@edtr-io/editor-ui'
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import * as React from 'react'
 
 import { videoState } from '.'
 import { VideoRenderer } from './renderer'
 
 export const VideoEditor = (
-  props: StatefulPluginEditorProps<typeof videoState> & {
+  props: PluginEditorProps<typeof videoState> & {
     renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
   }
 ) => {

--- a/packages/plugins/video/src/index.tsx
+++ b/packages/plugins/video/src/index.tsx
@@ -1,4 +1,4 @@
-import { StatefulPlugin, string, object, migratable } from '@edtr-io/plugin'
+import { Plugin, string, object, migratable } from '@edtr-io/plugin'
 import { createIcon, faFilm } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -11,7 +11,7 @@ export const videoState = migratable(stateV0).migrate(stateV1, src => {
   return { src, alt: '' }
 })
 
-export const videoPlugin: StatefulPlugin<typeof videoState> = {
+export const videoPlugin: Plugin<typeof videoState> = {
   //eslint-disable-next-line react/display-name
   Component: props =>
     props.editable ? <VideoEditor {...props} /> : <VideoRenderer {...props} />,

--- a/packages/plugins/video/src/renderer.tsx
+++ b/packages/plugins/video/src/renderer.tsx
@@ -1,4 +1,4 @@
-import { StatefulPluginEditorProps } from '@edtr-io/plugin'
+import { PluginEditorProps } from '@edtr-io/plugin'
 import { Icon, styled, faFilm } from '@edtr-io/ui'
 import * as React from 'react'
 
@@ -48,7 +48,7 @@ const VideoIframe = styled.iframe({
   border: 'none'
 })
 
-export type VideoRendererProps = StatefulPluginEditorProps<
+export type VideoRendererProps = PluginEditorProps<
   typeof videoState
 > & {
   disableCursorEvents?: boolean

--- a/packages/plugins/video/src/renderer.tsx
+++ b/packages/plugins/video/src/renderer.tsx
@@ -48,9 +48,7 @@ const VideoIframe = styled.iframe({
   border: 'none'
 })
 
-export type VideoRendererProps = PluginEditorProps<
-  typeof videoState
-> & {
+export type VideoRendererProps = PluginEditorProps<typeof videoState> & {
   disableCursorEvents?: boolean
 }
 

--- a/packages/private/fixtures/src/plugins.tsx
+++ b/packages/private/fixtures/src/plugins.tsx
@@ -67,9 +67,6 @@ export const plugins = {
   text: textPlugin,
   video: videoPlugin,
 
-  stateless: {
-    Component: () => null
-  },
   stateful: {
     Component: () => null,
     state: statefulState

--- a/packages/private/plugin-state/src/index.ts
+++ b/packages/private/plugin-state/src/index.ts
@@ -19,12 +19,15 @@ export interface StateType<S = any, T = S, R = unknown> {
    * Initializes the public API for usage in plugin components
    *
    * @param state - current state
-   * @param onChange - callback to set the state, accepts a [[StateUpdater]]
+   * @param onChange - callback to set the state, accepts a [[StateUpdater]] and an optional [[StateExecutor]]
    * @param pluginProps - additional props that should be passed down to the component. Only used by [[child]]
    */
   init(
     state: T,
-    onChange: (change: StateUpdater<T>) => void,
+    onChange: (
+      initial: StateUpdater<T>,
+      executor?: StateExecutor<StateUpdater<T>>
+    ) => void,
     pluginProps?: PluginProps
   ): R
 
@@ -70,37 +73,25 @@ export interface StateType<S = any, T = S, R = unknown> {
  * @param helpers - helpers (e.g. to insert an document in the store)
  * @returns new state
  */
-export type Updater<T> = (
+export type StateUpdater<T> = (
   previousState: T,
   helpers: StoreDeserializeHelpers
 ) => T
 
 /**
- * Describes an update to the state of a plugin and optionally asynchronous changes.
+ * Describes an asynchronous state update
  *
- * @param immediate - [[Updater]] to set the immediate state
- * @param resolver - Callback to change the value asynchronously. The callback receives three functions (resolve, reject, next) as params.
- * These can be called to apply further state updates. Once resolve or reject is called this handling is finished.
- */
-export type StateUpdater<T> = AsyncResolver<Updater<T>>
-
-/**
- * Describes an async process
- *
- * @param immediate - immediate value
- * @param resolver - Callback to change the value asynchronously. The callback receives three functions (resolve, reject, next) as params.
- * These can be called to apply further values. Once resolve or reject is called this handling is finished.
+ * @param resolve - Callback to set the state after the asynchronous process has been completed successfully. Should only be called at most once.
+ * @param reject - Callback to set the state after the asynchronous process has been completed unsuccessfully. Should only be called at most once.
+ * @param next - Callback to update the state while it is still pending
  *
  * @typeparam T - type of the immediate and async values
  */
-export interface AsyncResolver<T> {
-  immediate: T
-  resolver?: (
-    resolve: (value: T) => void,
-    reject: (value: T) => void,
-    next: (value: T) => void
-  ) => void
-}
+export type StateExecutor<T> = (
+  resolve: (value: T) => void,
+  reject: (value: T) => void,
+  next: (value: T) => void
+) => void
 
 /**
  * Describes a child document

--- a/packages/private/plugin-state/src/index.ts
+++ b/packages/private/plugin-state/src/index.ts
@@ -1,4 +1,5 @@
 import { DocumentEditorProps } from '@edtr-io/internal__document-editor'
+import { Reversible } from '@edtr-io/store/src/actions'
 
 /**
  * @module @edtr-io/plugin
@@ -63,6 +64,8 @@ export interface StateType<S = any, T = S, R = unknown> {
   getFocusableChildren(state: T): FocusableChild[]
 }
 
+export type Updater<T> = (previousState: T, helpers: StoreDeserializeHelpers) => T
+
 /**
  * A state updater will get called with the current state and helpers and should return the new state
  *
@@ -70,10 +73,14 @@ export interface StateType<S = any, T = S, R = unknown> {
  * @param helpers - helpers (e.g. to insert an document in the store)
  * @returns new state
  */
-export type StateUpdater<T> = (
-  previousState: T,
-  helpers: StoreDeserializeHelpers
-) => T
+export interface StateUpdater<T> {
+  immediateState: Updater<T>
+  resolver?: (
+    resolve: (updater: Updater<T>) => void,
+    reject: (updater: Updater<T>) => void,
+    next: (updater: Updater<T>) => void
+  ) => void
+}
 
 /**
  * Describes a child document

--- a/packages/private/plugin-state/src/index.ts
+++ b/packages/private/plugin-state/src/index.ts
@@ -1,5 +1,4 @@
 import { DocumentEditorProps } from '@edtr-io/internal__document-editor'
-import { Reversible } from '@edtr-io/store/src/actions'
 
 /**
  * @module @edtr-io/plugin
@@ -64,7 +63,10 @@ export interface StateType<S = any, T = S, R = unknown> {
   getFocusableChildren(state: T): FocusableChild[]
 }
 
-export type Updater<T> = (previousState: T, helpers: StoreDeserializeHelpers) => T
+export type Updater<T> = (
+  previousState: T,
+  helpers: StoreDeserializeHelpers
+) => T
 
 /**
  * A state updater will get called with the current state and helpers and should return the new state

--- a/packages/private/plugin-state/src/index.ts
+++ b/packages/private/plugin-state/src/index.ts
@@ -75,7 +75,6 @@ export type Updater<T> = (
   helpers: StoreDeserializeHelpers
 ) => T
 
-
 /**
  * Describes an update to the state of a plugin and optionally asynchronous changes.
  *

--- a/packages/private/plugin-state/src/index.ts
+++ b/packages/private/plugin-state/src/index.ts
@@ -63,24 +63,43 @@ export interface StateType<S = any, T = S, R = unknown> {
   getFocusableChildren(state: T): FocusableChild[]
 }
 
-export type Updater<T> = (
-  previousState: T,
-  helpers: StoreDeserializeHelpers
-) => T
-
 /**
- * A state updater will get called with the current state and helpers and should return the new state
+ * An updater will get called with the current state and helpers and should return the new state
  *
  * @param previousState - current state at the time the change is applied
  * @param helpers - helpers (e.g. to insert an document in the store)
  * @returns new state
  */
-export interface StateUpdater<T> {
-  immediateState: Updater<T>
+export type Updater<T> = (
+  previousState: T,
+  helpers: StoreDeserializeHelpers
+) => T
+
+
+/**
+ * Describes an update to the state of a plugin and optionally asynchronous changes.
+ *
+ * @param immediate - [[Updater]] to set the immediate state
+ * @param resolver - Callback to change the value asynchronously. The callback receives three functions (resolve, reject, next) as params.
+ * These can be called to apply further state updates. Once resolve or reject is called this handling is finished.
+ */
+export type StateUpdater<T> = AsyncResolver<Updater<T>>
+
+/**
+ * Describes an async process
+ *
+ * @param immediate - immediate value
+ * @param resolver - Callback to change the value asynchronously. The callback receives three functions (resolve, reject, next) as params.
+ * These can be called to apply further values. Once resolve or reject is called this handling is finished.
+ *
+ * @typeparam T - type of the immediate and async values
+ */
+export interface AsyncResolver<T> {
+  immediate: T
   resolver?: (
-    resolve: (updater: Updater<T>) => void,
-    reject: (updater: Updater<T>) => void,
-    next: (updater: Updater<T>) => void
+    resolve: (value: T) => void,
+    reject: (value: T) => void,
+    next: (value: T) => void
   ) => void
 }
 

--- a/packages/private/plugin/src/index.ts
+++ b/packages/private/plugin/src/index.ts
@@ -11,105 +11,16 @@ import {
 import * as React from 'react'
 
 /**
- * An Edtr.io plugin is either a [[StatelessPlugin]] or a [[StatefulPlugin]]
- *
- * @typeparam S - [[StateType]] of the plugin (only used when the plugin is stateful)
- * @typeparam Props - additional props that the plugin component accepts
- */
-export type Plugin<
-  S extends StateType = StateType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Props = any
-> = StatelessPlugin<Props> | StatefulPlugin<S, Props>
-
-/**
- * An Edtr.io plugin without state
- *
- * @typeparam Props - additional props that the plugin component accepts
- */
-export interface StatelessPlugin<Props = {}> {
-  /**
-   * React component that will be used to render the plugin. It accepts [[StatelessPluginEditorProps]] and `Props`..
-   */
-  Component: React.ComponentType<StatelessPluginEditorProps & Props>
-
-  /**
-   * May be provided to let the plugin respond to [`paste` events](https://developer.mozilla.org/docs/Web/API/Element/paste_event)
-   *
-   * @param data - the [DataTransfer](https://developer.mozilla.orgdocs/Web/API/DataTransfer) object of the corresponding [`paste` event](https://developer.mozilla.org/docs/Web/API/Element/paste_event)
-   * @returns an empty object if you want to handle the [`paste` event](https://developer.mozilla.org/docs/Web/API/Element/paste_event)
-   */
-  onPaste?(data: DataTransfer): void | { state?: undefined }
-
-  /**
-   * Deprecated plugin meta data
-   *
-   * @deprecated
-   */
-  title?: string
-  /**
-   * Deprecated plugin meta data
-   *
-   * @deprecated
-   */
-  icon?: React.ComponentType
-  /**
-   * Deprecated plugin meta data
-   *
-   * @deprecated
-   */
-  description?: string
-}
-
-/**
- * Props for the component of a [[StatelessPlugin]]
- */
-export interface StatelessPluginEditorProps {
-  /**
-   * ID of the document
-   */
-  id: string
-
-  /**
-   * Name of the plugin as defined in the registry. Will be removed as soon as we found a better solution for that
-   *
-   * @deprecated
-   */
-  name: string
-
-  /**
-   * `true` if the document is currently editable
-   */
-  editable: boolean
-
-  /**
-   * `true` if the document is currently focused
-   */
-  focused: boolean
-
-  /**
-   * Ref to use for an input element. The element will receive focus, when the plugin is focused.
-   */
-  defaultFocusRef: React.RefObject<HTMLInputElement & HTMLTextAreaElement>
-
-  /**
-   * Allows the plugin to render into the plugin settings
-   *
-   * @param children - content to render
-   */
-  renderIntoSettings(children: React.ReactNode): React.ReactNode
-}
-
-/**
  * An Edtr.io plugin with state
  *
  * @typeparam S - [[StateType]] of the plugin
+ * @typeparam Props - additional props that the plugin component accepts
  */
-export interface StatefulPlugin<S extends StateType, Props = {}> {
+export interface Plugin<S extends StateType = StateType, Props = {}> {
   /**
-   * React component that will be used to render the plugin. It accepts [[StatefulPluginEditorProps]] and `Props`.
+   * React component that will be used to render the plugin. It accepts [[PluginEditorProps]] and `Props`.
    */
-  Component: React.ComponentType<StatefulPluginEditorProps<S> & Props>
+  Component: React.ComponentType<PluginEditorProps<S> & Props>
 
   /**
    * [[StateType]] of the plugin
@@ -161,43 +72,50 @@ export interface StatefulPlugin<S extends StateType, Props = {}> {
 }
 
 /**
- * Props for the component of a [[StatefulPlugin]]
+ * Props for the component of a [[Plugin]]
  *
  * @typeparam S - [[StateType]] of the plugin
  */
-export interface StatefulPluginEditorProps<S extends StateType = StateType>
-  extends StatelessPluginEditorProps {
+export interface PluginEditorProps<S extends StateType = StateType> {
   /**
    * Current state of the document
    *
    * @see [[StateTypeReturnType]]
    */
   state: StateTypeReturnType<S>
-}
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/**
- * [Type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types) that checks whether the given [[Plugin]] is stateful
- *
- * @param plugin - plugin to check
- * @typeparam S - [[StateType]] to assert
- * @returns `true` if the plugin is stateful
- */
-export function isStatefulPlugin<S extends StateType>(
-  plugin: Plugin<S>
-): plugin is StatefulPlugin<S, any> {
-  return typeof (plugin as StatefulPlugin<S, any>).state !== 'undefined'
-}
+  /**
+   * ID of the document
+   */
+  id: string
 
-/**
- * [Type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types) that checks whether the given [[Plugin]] is stateless
- *
- * @param plugin - plugin to check
- * @returns `true` if the plugin is stateless
- */
-export function isStatelessPlugin(
-  plugin: Plugin
-): plugin is StatelessPlugin<any> {
-  return !isStatefulPlugin(plugin)
+  /**
+   * Name of the plugin as defined in the registry. Will be removed as soon as we found a better solution for that
+   *
+   * @deprecated
+   */
+  name: string
+
+  /**
+   * `true` if the document is currently editable
+   */
+  editable: boolean
+
+  /**
+   * `true` if the document is currently focused
+   */
+  focused: boolean
+
+  /**
+   * Ref to use for an input element. The element will receive focus, when the plugin is focused.
+   */
+  defaultFocusRef: React.RefObject<HTMLInputElement & HTMLTextAreaElement>
+
+  /**
+   * Allows the plugin to render into the plugin settings
+   *
+   * @param children - content to render
+   */
+  renderIntoSettings(children: React.ReactNode): React.ReactNode
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/public/core/__tests__/index.tsx
+++ b/packages/public/core/__tests__/index.tsx
@@ -18,14 +18,14 @@ beforeEach(() => {
 test('default plugin', () => {
   renderDocument(document => {
     if (!document) throw new Error('No document found')
-    expect(document.plugin).toEqual('stateless')
+    expect(document.plugin).toEqual('stateful')
   })
 })
 
 function renderDocument(onChange: StateProps['onChange']) {
   act(() => {
     ReactDOM.render(
-      <Editor plugins={plugins} defaultPlugin="stateless">
+      <Editor plugins={plugins} defaultPlugin="stateful">
         {children => {
           return (
             <React.Fragment>

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -3,7 +3,11 @@
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import { Plugin, PluginEditorProps } from '@edtr-io/internal__plugin'
-import { StateType, StateUpdater } from '@edtr-io/internal__plugin-state'
+import {
+  StateType,
+  StateUpdater,
+  StateExecutor
+} from '@edtr-io/internal__plugin-state'
 import {
   change,
   DocumentState,
@@ -226,11 +230,17 @@ function getPluginEditorProps<S extends StateType>({
   dispatch: ReturnType<typeof useScopedDispatch>
   pluginProps: DocumentProps['pluginProps']
 }): Omit<PluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'> {
-  const onChange = (updater: StateUpdater<unknown>) => {
+  const onChange = (
+    initial: StateUpdater<unknown>,
+    executor?: StateExecutor<StateUpdater<unknown>>
+  ) => {
     dispatch(
       change({
         id,
-        state: updater
+        state: {
+          initial,
+          executor
+        }
       })
     )
   }

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -2,10 +2,7 @@
  * @module @edtr-io/core
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import {
-  Plugin,
-  PluginEditorProps
-} from '@edtr-io/internal__plugin'
+import { Plugin, PluginEditorProps } from '@edtr-io/internal__plugin'
 import { StateType, StateUpdater } from '@edtr-io/internal__plugin-state'
 import {
   change,

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -8,10 +8,7 @@ import {
   StatefulPluginEditorProps,
   StatelessPluginEditorProps
 } from '@edtr-io/internal__plugin'
-import {
-  StateType, StateUpdater,
-  StoreDeserializeHelpers
-} from '@edtr-io/internal__plugin-state'
+import { StateType, StateUpdater } from '@edtr-io/internal__plugin-state'
 import {
   change,
   DocumentState,
@@ -239,9 +236,7 @@ function getPluginEditorProps<S extends StateType>({
   | Omit<StatefulPluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'>
   | Omit<StatelessPluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'> {
   if (isStatefulPlugin(plugin)) {
-    const onChange = (
-      updater: StateUpdater<unknown>,
-    ) => {
+    const onChange = (updater: StateUpdater<unknown>) => {
       dispatch(
         change({
           id,

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -3,10 +3,8 @@
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import {
-  isStatefulPlugin,
   Plugin,
-  StatefulPluginEditorProps,
-  StatelessPluginEditorProps
+  PluginEditorProps
 } from '@edtr-io/internal__plugin'
 import { StateType, StateUpdater } from '@edtr-io/internal__plugin-state'
 import {
@@ -68,8 +66,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
       container.current &&
       document &&
       plugin &&
-      (!isStatefulPlugin(plugin) ||
-        !plugin.state.getFocusableChildren(document.state).length)
+      !plugin.state.getFocusableChildren(document.state).length
     ) {
       container.current.focus()
     }
@@ -94,7 +91,6 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
       if (
         e &&
         plugin &&
-        isStatefulPlugin(plugin) &&
         typeof plugin.onKeyDown === 'function' &&
         !plugin.onKeyDown(e)
       ) {
@@ -232,37 +228,25 @@ function getPluginEditorProps<S extends StateType>({
   plugin: Plugin
   dispatch: ReturnType<typeof useScopedDispatch>
   pluginProps: DocumentProps['pluginProps']
-}):
-  | Omit<StatefulPluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'>
-  | Omit<StatelessPluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'> {
-  if (isStatefulPlugin(plugin)) {
-    const onChange = (updater: StateUpdater<unknown>) => {
-      dispatch(
-        change({
-          id,
-          state: updater
-        })
-      )
-    }
-    const state = plugin.state.init(document.state, onChange, {
-      ...pluginProps,
-      name: document.plugin
-    })
-    return {
-      ...pluginProps,
-      id,
-      editable: true,
-      focused,
-      name: document.plugin,
-      state
-    }
+}): Omit<PluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'> {
+  const onChange = (updater: StateUpdater<unknown>) => {
+    dispatch(
+      change({
+        id,
+        state: updater
+      })
+    )
   }
-
+  const state = plugin.state.init(document.state, onChange, {
+    ...pluginProps,
+    name: document.plugin
+  })
   return {
     ...pluginProps,
     id,
     editable: true,
     focused,
-    name: document.plugin
+    name: document.plugin,
+    state
   }
 }

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -9,7 +9,7 @@ import {
   StatelessPluginEditorProps
 } from '@edtr-io/internal__plugin'
 import {
-  StateType,
+  StateType, StateUpdater,
   StoreDeserializeHelpers
 } from '@edtr-io/internal__plugin-state'
 import {
@@ -240,7 +240,7 @@ function getPluginEditorProps<S extends StateType>({
   | Omit<StatelessPluginEditorProps, 'defaultFocusRef' | 'renderIntoSettings'> {
   if (isStatefulPlugin(plugin)) {
     const onChange = (
-      updater: (value: unknown, helpers: StoreDeserializeHelpers) => void
+      updater: StateUpdater<unknown>,
     ) => {
       dispatch(
         change({

--- a/packages/public/core/src/document/renderer.tsx
+++ b/packages/public/core/src/document/renderer.tsx
@@ -2,7 +2,6 @@
  * @module @edtr-io/core
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { isStatefulPlugin } from '@edtr-io/internal__plugin'
 import { getDocument, getPlugin } from '@edtr-io/store'
 import * as React from 'react'
 
@@ -14,6 +13,7 @@ export function DocumentRenderer({ id, pluginProps }: DocumentProps) {
   const plugin = useScopedSelector(
     state => document && getPlugin(document.plugin)(state)
   )
+  const focusRef = React.useRef<HTMLInputElement & HTMLTextAreaElement>(null)
   if (!document) return null
   if (!plugin) {
     // TODO:
@@ -22,9 +22,17 @@ export function DocumentRenderer({ id, pluginProps }: DocumentProps) {
     return null
   }
 
-  let pluginState: unknown
-  if (isStatefulPlugin(plugin)) {
-    pluginState = plugin.state.init(document.state, () => {})
-  }
-  return <plugin.Component {...pluginProps} state={pluginState} />
+  const pluginState = plugin.state.init(document.state, () => {})
+  return (
+    <plugin.Component
+      {...pluginProps}
+      state={pluginState}
+      id={id}
+      name={document.plugin}
+      editable={false}
+      focused={false}
+      defaultFocusRef={focusRef}
+      renderIntoSettings={() => null}
+    />
+  )
 }

--- a/packages/public/plugin/__tests__/async.ts
+++ b/packages/public/plugin/__tests__/async.ts
@@ -1,0 +1,23 @@
+import { asyncScalar } from '@edtr-io/plugin'
+import { wait } from '@edtr-io/store/__helpers__'
+
+describe('async', () => {
+  test('temporary initial state', () => {
+    const state = asyncScalar({
+      immediate: 3,
+      resolver: (resolve, reject, next) => {
+        setTimeout(() => {
+          next(2)
+          setTimeout(() => {
+            next(1)
+            setTimeout(() => {
+              resolve(0)
+            }, 100)
+          }, 100)
+        }, 100)
+      }
+    })
+    expect(state).toEqual(3)
+    wait(3)
+  })
+})

--- a/packages/public/plugin/__tests__/async.ts
+++ b/packages/public/plugin/__tests__/async.ts
@@ -1,23 +1,84 @@
-// import { asyncScalar } from '@edtr-io/plugin'
-// import { wait } from '@edtr-io/store/__helpers__'
+import { asyncScalar, StateUpdater } from '@edtr-io/plugin'
 
-describe('async', () => {
-  test('temporary initial state', () => {
-    // const state = asyncScalar({
-    //   immediate: 3,
-    //   resolver: (resolve, reject, next) => {
-    //     setTimeout(() => {
-    //       next(2)
-    //       setTimeout(() => {
-    //         next(1)
-    //         setTimeout(() => {
-    //           resolve(0)
-    //         }, 100)
-    //       }, 100)
-    //     }, 100)
-    //   }
-    // })
-    // expect(state).toEqual(3)
-    // wait(3)
+const deserializeHelpers = {
+  createDocument: () => {}
+}
+const serializeHelpers = {
+  getDocument: () => null
+}
+
+describe('asyncScalar', () => {
+  interface TempState {
+    tmp: number
+  }
+
+  function isTempState(value: number | TempState) {
+    return typeof (value as TempState).tmp !== 'undefined'
+  }
+
+  test('initial state', () => {
+    const state = asyncScalar<number, TempState>(3, isTempState)
+    expect(state.createInitialState(deserializeHelpers)).toEqual(3)
+  })
+
+  test('remove temp state on serialize', () => {
+    const state = asyncScalar<number, TempState>(0, isTempState)
+    expect(state.serialize({ tmp: 4 }, serializeHelpers)).toEqual(0)
+    expect(state.serialize(4, serializeHelpers)).toEqual(4)
+  })
+
+  test('deserialize just passes through', () => {
+    const state = asyncScalar<number, TempState>(0, isTempState)
+    expect(state.deserialize(4, deserializeHelpers)).toEqual(4)
+  })
+
+  test('async set', async () => {
+    const initial = 0
+    const state = asyncScalar<number, TempState>(initial, isTempState)
+
+    let store: number | TempState = initial
+    const onChange = (updater: StateUpdater<number | TempState>) => {
+      store = updater.immediate(store, deserializeHelpers)
+      if (updater.resolver) {
+        updater.resolver(
+          resolveUpdater => {
+            store = resolveUpdater(store, deserializeHelpers)
+          },
+          rejectUpdater => {
+            store = rejectUpdater(store, deserializeHelpers)
+          },
+          nextUpdater => {
+            store = nextUpdater(store, deserializeHelpers)
+          }
+        )
+      }
+    }
+    const scalarValue = state.init(initial, onChange)
+
+    scalarValue.set({
+      immediate: { tmp: 1 },
+      resolver: (resolve, reject, next) => {
+        setTimeout(() => {
+          next({ tmp: 2 })
+          setTimeout(() => {
+            next({ tmp: 3 })
+            setTimeout(() => {
+              resolve(3)
+            }, 100)
+          }, 100)
+        }, 100)
+      }
+    })
+    expect(store).toEqual({ tmp: 1 })
+    await wait(400)
+    expect(store).toEqual(3)
   })
 })
+
+function wait(time = 10): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+    }, time)
+  })
+}

--- a/packages/public/plugin/__tests__/async.ts
+++ b/packages/public/plugin/__tests__/async.ts
@@ -3,21 +3,21 @@ import { wait } from '@edtr-io/store/__helpers__'
 
 describe('async', () => {
   test('temporary initial state', () => {
-    const state = asyncScalar({
-      immediate: 3,
-      resolver: (resolve, reject, next) => {
-        setTimeout(() => {
-          next(2)
-          setTimeout(() => {
-            next(1)
-            setTimeout(() => {
-              resolve(0)
-            }, 100)
-          }, 100)
-        }, 100)
-      }
-    })
-    expect(state).toEqual(3)
-    wait(3)
+    // const state = asyncScalar({
+    //   immediate: 3,
+    //   resolver: (resolve, reject, next) => {
+    //     setTimeout(() => {
+    //       next(2)
+    //       setTimeout(() => {
+    //         next(1)
+    //         setTimeout(() => {
+    //           resolve(0)
+    //         }, 100)
+    //       }, 100)
+    //     }, 100)
+    //   }
+    // })
+    // expect(state).toEqual(3)
+    // wait(3)
   })
 })

--- a/packages/public/plugin/__tests__/async.ts
+++ b/packages/public/plugin/__tests__/async.ts
@@ -1,5 +1,5 @@
-import { asyncScalar } from '@edtr-io/plugin'
-import { wait } from '@edtr-io/store/__helpers__'
+// import { asyncScalar } from '@edtr-io/plugin'
+// import { wait } from '@edtr-io/store/__helpers__'
 
 describe('async', () => {
   test('temporary initial state', () => {

--- a/packages/public/plugin/__tests__/list.ts
+++ b/packages/public/plugin/__tests__/list.ts
@@ -15,7 +15,7 @@ describe('list', () => {
   let helpers: StoreDeserializeHelpers & { createDocument: jest.Mock }
   let store: T[]
   const onChange = (updater: StateUpdater<T[]>) => {
-    store = updater.immediateState(store, helpers)
+    store = updater.immediate(store, helpers)
   }
 
   beforeEach(() => {

--- a/packages/public/plugin/__tests__/list.ts
+++ b/packages/public/plugin/__tests__/list.ts
@@ -1,4 +1,4 @@
-import { child, list, StoreDeserializeHelpers, string } from '../src'
+import { child, list, StateUpdater, StoreDeserializeHelpers, string } from '../src'
 
 describe('list', () => {
   interface T {
@@ -9,9 +9,9 @@ describe('list', () => {
   let helpers: StoreDeserializeHelpers & { createDocument: jest.Mock }
   let store: T[]
   const onChange = (
-    updater: (oldItems: T[], helpers: StoreDeserializeHelpers) => T[]
+    updater: StateUpdater<T[]>
   ) => {
-    store = updater(store, helpers)
+    store = updater.immediateState(store, helpers)
   }
 
   beforeEach(() => {

--- a/packages/public/plugin/__tests__/list.ts
+++ b/packages/public/plugin/__tests__/list.ts
@@ -1,9 +1,9 @@
 import {
   child,
   list,
-  StateUpdater,
   StoreDeserializeHelpers,
-  string
+  string,
+  StateUpdater
 } from '../src'
 
 describe('list', () => {
@@ -14,8 +14,8 @@ describe('list', () => {
 
   let helpers: StoreDeserializeHelpers & { createDocument: jest.Mock }
   let store: T[]
-  const onChange = (updater: StateUpdater<T[]>) => {
-    store = updater.immediate(store, helpers)
+  const onChange = (initial: StateUpdater<T[]>) => {
+    store = initial(store, helpers)
   }
 
   beforeEach(() => {

--- a/packages/public/plugin/__tests__/list.ts
+++ b/packages/public/plugin/__tests__/list.ts
@@ -1,4 +1,10 @@
-import { child, list, StateUpdater, StoreDeserializeHelpers, string } from '../src'
+import {
+  child,
+  list,
+  StateUpdater,
+  StoreDeserializeHelpers,
+  string
+} from '../src'
 
 describe('list', () => {
   interface T {
@@ -8,9 +14,7 @@ describe('list', () => {
 
   let helpers: StoreDeserializeHelpers & { createDocument: jest.Mock }
   let store: T[]
-  const onChange = (
-    updater: StateUpdater<T[]>
-  ) => {
+  const onChange = (updater: StateUpdater<T[]>) => {
     store = updater.immediateState(store, helpers)
   }
 

--- a/packages/public/plugin/__tests__/object.ts
+++ b/packages/public/plugin/__tests__/object.ts
@@ -1,4 +1,10 @@
-import { child, number, object, StateUpdater, StoreDeserializeHelpers } from '../src'
+import {
+  child,
+  number,
+  object,
+  StateUpdater,
+  StoreDeserializeHelpers
+} from '../src'
 
 describe('object', () => {
   let helpers: StoreDeserializeHelpers<string, number> & {
@@ -110,9 +116,7 @@ describe('object', () => {
     }
 
     let store = initial
-    const onChange = (
-      updater: StateUpdater<typeof initial>
-    ) => {
+    const onChange = (updater: StateUpdater<typeof initial>) => {
       store = updater.immediateState(store, helpers)
     }
 

--- a/packages/public/plugin/__tests__/object.ts
+++ b/packages/public/plugin/__tests__/object.ts
@@ -1,4 +1,4 @@
-import { child, number, object, StoreDeserializeHelpers } from '../src'
+import { child, number, object, StateUpdater, StoreDeserializeHelpers } from '../src'
 
 describe('object', () => {
   let helpers: StoreDeserializeHelpers<string, number> & {
@@ -111,12 +111,9 @@ describe('object', () => {
 
     let store = initial
     const onChange = (
-      updater: (
-        oldValue: typeof initial,
-        helpers: StoreDeserializeHelpers
-      ) => typeof initial
+      updater: StateUpdater<typeof initial>
     ) => {
-      store = updater(store, helpers)
+      store = updater.immediateState(store, helpers)
     }
 
     const objValue = state.init(initial, onChange)

--- a/packages/public/plugin/__tests__/object.ts
+++ b/packages/public/plugin/__tests__/object.ts
@@ -117,7 +117,7 @@ describe('object', () => {
 
     let store = initial
     const onChange = (updater: StateUpdater<typeof initial>) => {
-      store = updater.immediateState(store, helpers)
+      store = updater.immediate(store, helpers)
     }
 
     const objValue = state.init(initial, onChange)

--- a/packages/public/plugin/__tests__/object.ts
+++ b/packages/public/plugin/__tests__/object.ts
@@ -2,8 +2,8 @@ import {
   child,
   number,
   object,
-  StateUpdater,
-  StoreDeserializeHelpers
+  StoreDeserializeHelpers,
+  StateUpdater
 } from '../src'
 
 describe('object', () => {
@@ -110,17 +110,17 @@ describe('object', () => {
       foo: child(),
       counter: number()
     })
-    const initial = {
+    const initialState = {
       foo: 'foo',
       counter: 5
     }
 
-    let store = initial
-    const onChange = (updater: StateUpdater<typeof initial>) => {
-      store = updater.immediate(store, helpers)
+    let store = initialState
+    const onChange = (initial: StateUpdater<typeof initialState>) => {
+      store = initial(store, helpers)
     }
 
-    const objValue = state.init(initial, onChange)
+    const objValue = state.init(initialState, onChange)
     objValue.counter.set(value => value + 1)
     expect(store).toEqual({
       foo: 'foo',
@@ -133,11 +133,11 @@ describe('object', () => {
       foo: child(),
       counter: number()
     })
-    const initial = {
+    const initialState = {
       foo: 'foo',
       counter: 5
     }
 
-    expect(state.getFocusableChildren(initial)).toEqual([{ id: 'foo' }])
+    expect(state.getFocusableChildren(initialState)).toEqual([{ id: 'foo' }])
   })
 })

--- a/packages/public/plugin/__tests__/scalar.ts
+++ b/packages/public/plugin/__tests__/scalar.ts
@@ -83,7 +83,7 @@ describe('serialized scalar', () => {
     const initial = { value: 0 }
     let store = initial
     const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -96,7 +96,7 @@ describe('serialized scalar', () => {
     const initial = { value: 0 }
     let store = initial
     const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -109,7 +109,7 @@ describe('serialized scalar', () => {
     const initial = { value: 0 }
     let store = initial
     const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -154,7 +154,7 @@ describe('boolean', () => {
     const state = boolean(initial)
     let store = initial
     const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
     const booleanValue = state.init(initial, onChange)
     booleanValue.value = true
@@ -166,7 +166,7 @@ describe('boolean', () => {
     const state = boolean(initial)
     let store = initial
     const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
 
     const booleanValue = state.init(initial, onChange)
@@ -179,7 +179,7 @@ describe('boolean', () => {
     const state = boolean(initial)
     let store = initial
     const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediateState(store, deserializeHelpers)
+      store = updater.immediate(store, deserializeHelpers)
     }
 
     const booleanValue = state.init(initial, onChange)

--- a/packages/public/plugin/__tests__/scalar.ts
+++ b/packages/public/plugin/__tests__/scalar.ts
@@ -5,7 +5,8 @@ import {
   serializedScalar,
   StoreDeserializeHelpers,
   string,
-  Serializer
+  Serializer,
+  StateUpdater
 } from '../src'
 
 const deserializeHelpers = {
@@ -82,10 +83,8 @@ describe('serialized scalar', () => {
     const state = serializedScalar({ value: 0 }, serializer)
     const initial = { value: 0 }
     let store = initial
-    const onChange = (
-      updater: (oldValue: T, helpers: StoreDeserializeHelpers) => T
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<T>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -97,10 +96,8 @@ describe('serialized scalar', () => {
     const state = serializedScalar({ value: 0 }, serializer)
     const initial = { value: 0 }
     let store = initial
-    const onChange = (
-      updater: (oldValue: T, helpers: StoreDeserializeHelpers) => T
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<T>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -112,10 +109,8 @@ describe('serialized scalar', () => {
     const state = serializedScalar({ value: 0 }, serializer)
     const initial = { value: 0 }
     let store = initial
-    const onChange = (
-      updater: (oldValue: T, helpers: StoreDeserializeHelpers) => T
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<T>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
     const scalarValue = state.init(initial, onChange)
 
@@ -159,12 +154,9 @@ describe('boolean', () => {
     const initial = false
     const state = boolean(initial)
     let store = initial
-    const onChange = (
-      updater: (oldValue: boolean, helpers: StoreDeserializeHelpers) => boolean
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<boolean>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
-
     const booleanValue = state.init(initial, onChange)
     booleanValue.value = true
     expect(store).toEqual(true)
@@ -174,10 +166,8 @@ describe('boolean', () => {
     const initial = false
     const state = boolean(initial)
     let store = initial
-    const onChange = (
-      updater: (oldValue: boolean, helpers: StoreDeserializeHelpers) => boolean
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<boolean>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
 
     const booleanValue = state.init(initial, onChange)
@@ -189,10 +179,8 @@ describe('boolean', () => {
     const initial = false
     const state = boolean(initial)
     let store = initial
-    const onChange = (
-      updater: (oldValue: boolean, helpers: StoreDeserializeHelpers) => boolean
-    ) => {
-      store = updater(store, deserializeHelpers)
+    const onChange = (updater: StateUpdater<boolean>) => {
+      store = updater.immediateState(store, deserializeHelpers)
     }
 
     const booleanValue = state.init(initial, onChange)

--- a/packages/public/plugin/__tests__/scalar.ts
+++ b/packages/public/plugin/__tests__/scalar.ts
@@ -3,7 +3,6 @@ import {
   number,
   scalar,
   serializedScalar,
-  StoreDeserializeHelpers,
   string,
   Serializer,
   StateUpdater

--- a/packages/public/plugin/__tests__/scalar.ts
+++ b/packages/public/plugin/__tests__/scalar.ts
@@ -80,12 +80,12 @@ describe('serialized scalar', () => {
 
   test('return type, value setter', () => {
     const state = serializedScalar({ value: 0 }, serializer)
-    const initial = { value: 0 }
-    let store = initial
-    const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = { value: 0 }
+    let store = initialState
+    const onChange = (initial: StateUpdater<T>) => {
+      store = initial(store, deserializeHelpers)
     }
-    const scalarValue = state.init(initial, onChange)
+    const scalarValue = state.init(initialState, onChange)
 
     scalarValue.value = { value: 1 }
     expect(store).toEqual({ value: 1 })
@@ -93,12 +93,12 @@ describe('serialized scalar', () => {
 
   test('return type, set (value)', () => {
     const state = serializedScalar({ value: 0 }, serializer)
-    const initial = { value: 0 }
-    let store = initial
-    const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = { value: 0 }
+    let store = initialState
+    const onChange = (initial: StateUpdater<T>) => {
+      store = initial(store, deserializeHelpers)
     }
-    const scalarValue = state.init(initial, onChange)
+    const scalarValue = state.init(initialState, onChange)
 
     scalarValue.set({ value: 1 })
     expect(store).toEqual({ value: 1 })
@@ -106,12 +106,12 @@ describe('serialized scalar', () => {
 
   test('return type, set (updater)', () => {
     const state = serializedScalar({ value: 0 }, serializer)
-    const initial = { value: 0 }
-    let store = initial
-    const onChange = (updater: StateUpdater<T>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = { value: 0 }
+    let store = initialState
+    const onChange = (initial: StateUpdater<T>) => {
+      store = initial(store, deserializeHelpers)
     }
-    const scalarValue = state.init(initial, onChange)
+    const scalarValue = state.init(initialState, onChange)
 
     scalarValue.set(({ value }) => {
       return { value: value + 1 }
@@ -150,39 +150,39 @@ describe('boolean', () => {
   })
 
   test('return type, value setter', () => {
-    const initial = false
-    const state = boolean(initial)
-    let store = initial
-    const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = false
+    const state = boolean(initialState)
+    let store = initialState
+    const onChange = (initial: StateUpdater<boolean>) => {
+      store = initial(store, deserializeHelpers)
     }
-    const booleanValue = state.init(initial, onChange)
+    const booleanValue = state.init(initialState, onChange)
     booleanValue.value = true
     expect(store).toEqual(true)
   })
 
   test('return type, value set (value)', () => {
-    const initial = false
-    const state = boolean(initial)
-    let store = initial
-    const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = false
+    const state = boolean(initialState)
+    let store = initialState
+    const onChange = (initial: StateUpdater<boolean>) => {
+      store = initial(store, deserializeHelpers)
     }
 
-    const booleanValue = state.init(initial, onChange)
+    const booleanValue = state.init(initialState, onChange)
     booleanValue.set(true)
     expect(store).toEqual(true)
   })
 
   test('return type, value set (updater)', () => {
-    const initial = false
-    const state = boolean(initial)
-    let store = initial
-    const onChange = (updater: StateUpdater<boolean>) => {
-      store = updater.immediate(store, deserializeHelpers)
+    const initialState = false
+    const state = boolean(initialState)
+    let store = initialState
+    const onChange = (initial: StateUpdater<boolean>) => {
+      store = initial(store, deserializeHelpers)
     }
 
-    const booleanValue = state.init(initial, onChange)
+    const booleanValue = state.init(initialState, onChange)
     booleanValue.set(value => !value)
     expect(store).toEqual(true)
   })

--- a/packages/public/plugin/src/child.tsx
+++ b/packages/public/plugin/src/child.tsx
@@ -61,11 +61,9 @@ export function child<K extends string, S = unknown>(
         id,
         render: memoizedRender(pluginProps || {}, id),
         replace: (plugin, state) => {
-          onChange({
-            immediate: (_id, helpers) => {
-              helpers.createDocument({ id, plugin, state })
-              return id
-            }
+          onChange((_id, helpers) => {
+            helpers.createDocument({ id, plugin, state })
+            return id
           })
         }
       }

--- a/packages/public/plugin/src/child.tsx
+++ b/packages/public/plugin/src/child.tsx
@@ -61,9 +61,11 @@ export function child<K extends string, S = unknown>(
         id,
         render: memoizedRender(pluginProps || {}, id),
         replace: (plugin, state) => {
-          onChange((_id, helpers) => {
-            helpers.createDocument({ id, plugin, state })
-            return id
+          onChange({
+            immediate: (_id, helpers) => {
+              helpers.createDocument({ id, plugin, state })
+              return id
+            }
           })
         }
       }

--- a/packages/public/plugin/src/list.ts
+++ b/packages/public/plugin/src/list.ts
@@ -69,36 +69,25 @@ export function list<S, T = S, U = unknown>(
               oldItems: WrappedValue[],
               helpers: StoreDeserializeHelpers
             ) => {
-              console.log(oldItems)
               const index = R.findIndex(R.propEq('id', id), oldItems)
               const result = R.update(
                 index,
                 { value: updater(oldItems[index].value, helpers), id: id },
                 oldItems
               )
-              console.log('result: ', result)
               return result
             }
           }
           onChange({
             immediate: wrapUpdater(stateUpdater.immediate),
             resolver: (resolve, reject, next) => {
-              console.log('list resolver', stateUpdater.resolver)
               if (!stateUpdater.resolver) {
                 resolve(wrapUpdater(stateUpdater.immediate))
               } else {
                 stateUpdater.resolver(
-                  innerUpdater => {
-                    console.log('resolve list'),
-                      resolve(wrapUpdater(innerUpdater))
-                  },
-                  innerUpdater => {
-                    console.log('reject list'),
-                      reject(wrapUpdater(innerUpdater))
-                  },
-                  innerUpdater => {
-                    console.log('next list'), next(wrapUpdater(innerUpdater))
-                  }
+                  innerUpdater => resolve(wrapUpdater(innerUpdater)),
+                  innerUpdater => reject(wrapUpdater(innerUpdater)),
+                  innerUpdater => next(wrapUpdater(innerUpdater))
                 )
               }
             }

--- a/packages/public/plugin/src/list.ts
+++ b/packages/public/plugin/src/list.ts
@@ -69,24 +69,36 @@ export function list<S, T = S, U = unknown>(
               oldItems: WrappedValue[],
               helpers: StoreDeserializeHelpers
             ) => {
+              console.log(oldItems)
               const index = R.findIndex(R.propEq('id', id), oldItems)
-              return R.update(
+              const result = R.update(
                 index,
                 { value: updater(oldItems[index].value, helpers), id: id },
                 oldItems
               )
+              console.log('result: ', result)
+              return result
             }
           }
           onChange({
             immediate: wrapUpdater(stateUpdater.immediate),
             resolver: (resolve, reject, next) => {
+              console.log('list resolver', stateUpdater.resolver)
               if (!stateUpdater.resolver) {
                 resolve(wrapUpdater(stateUpdater.immediate))
               } else {
                 stateUpdater.resolver(
-                  innerUpdater => resolve(wrapUpdater(innerUpdater)),
-                  innerUpdater => reject(wrapUpdater(innerUpdater)),
-                  innerUpdater => next(wrapUpdater(innerUpdater))
+                  innerUpdater => {
+                    console.log('resolve list'),
+                      resolve(wrapUpdater(innerUpdater))
+                  },
+                  innerUpdater => {
+                    console.log('reject list'),
+                      reject(wrapUpdater(innerUpdater))
+                  },
+                  innerUpdater => {
+                    console.log('next list'), next(wrapUpdater(innerUpdater))
+                  }
                 )
               }
             }

--- a/packages/public/plugin/src/list.ts
+++ b/packages/public/plugin/src/list.ts
@@ -40,7 +40,7 @@ export function list<S, T = S, U = unknown>(
       return Object.assign(items, {
         insert(index?: number, options?: S) {
           onChange({
-            immediateState: (items, helpers) => {
+            immediate: (items, helpers) => {
               const wrappedSubState = wrap(
                 options
                   ? type.deserialize(options, helpers)
@@ -55,10 +55,10 @@ export function list<S, T = S, U = unknown>(
           })
         },
         remove(index: number) {
-          onChange({ immediateState: items => R.remove(index, 1, items) })
+          onChange({ immediate: items => R.remove(index, 1, items) })
         },
         move(from: number, to: number) {
-          onChange({ immediateState: items => R.move(from, to, items) })
+          onChange({ immediate: items => R.move(from, to, items) })
         }
       })
 
@@ -78,10 +78,10 @@ export function list<S, T = S, U = unknown>(
             }
           }
           onChange({
-            immediateState: wrapUpdater(stateUpdater.immediateState),
+            immediate: wrapUpdater(stateUpdater.immediate),
             resolver: (resolve, reject, next) => {
               if (!stateUpdater.resolver) {
-                resolve(wrapUpdater(stateUpdater.immediateState))
+                resolve(wrapUpdater(stateUpdater.immediate))
               } else {
                 stateUpdater.resolver(
                   innerUpdater => resolve(wrapUpdater(innerUpdater)),

--- a/packages/public/plugin/src/object.ts
+++ b/packages/public/plugin/src/object.ts
@@ -41,8 +41,14 @@ export function object<Ds extends Record<string, StateType>>(
           function wrapUpdater(
             dispatcher: Updater<StateTypeReturnType<typeof type>>
           ): Updater<StateTypesValueType<Ds>> {
-            return (oldObj, helpers) =>
-              R.set(R.lensProp(key), dispatcher(oldObj[key], helpers), oldObj)
+            return (oldObj, helpers) => {
+              console.log(oldObj)
+              return R.set(
+                R.lensProp(key),
+                dispatcher(oldObj[key], helpers),
+                oldObj
+              )
+            }
           }
           onChange({
             immediate: wrapUpdater(stateHandler.immediate),

--- a/packages/public/plugin/src/object.ts
+++ b/packages/public/plugin/src/object.ts
@@ -45,10 +45,10 @@ export function object<Ds extends Record<string, StateType>>(
               R.set(R.lensProp(key), dispatcher(oldObj[key], helpers), oldObj)
           }
           onChange({
-            immediateState: wrapUpdater(stateHandler.immediateState),
+            immediate: wrapUpdater(stateHandler.immediate),
             resolver: (resolve, reject, next) => {
               if (!stateHandler.resolver) {
-                resolve(wrapUpdater(stateHandler.immediateState))
+                resolve(wrapUpdater(stateHandler.immediate))
               } else {
                 stateHandler.resolver(
                   innerUpdater => {

--- a/packages/public/plugin/src/object.ts
+++ b/packages/public/plugin/src/object.ts
@@ -42,7 +42,6 @@ export function object<Ds extends Record<string, StateType>>(
             dispatcher: Updater<StateTypeReturnType<typeof type>>
           ): Updater<StateTypesValueType<Ds>> {
             return (oldObj, helpers) => {
-              console.log(oldObj)
               return R.set(
                 R.lensProp(key),
                 dispatcher(oldObj[key], helpers),
@@ -57,15 +56,9 @@ export function object<Ds extends Record<string, StateType>>(
                 resolve(wrapUpdater(stateHandler.immediate))
               } else {
                 stateHandler.resolver(
-                  innerUpdater => {
-                    resolve(wrapUpdater(innerUpdater))
-                  },
-                  innerUpdater => {
-                    reject(wrapUpdater(innerUpdater))
-                  },
-                  innerUpdater => {
-                    next(wrapUpdater(innerUpdater))
-                  }
+                  innerUpdater => resolve(wrapUpdater(innerUpdater)),
+                  innerUpdater => reject(wrapUpdater(innerUpdater)),
+                  innerUpdater => next(wrapUpdater(innerUpdater))
                 )
               }
             }

--- a/packages/public/plugin/src/scalar.ts
+++ b/packages/public/plugin/src/scalar.ts
@@ -2,7 +2,11 @@
  * @module @edtr-io/plugin
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { StateType } from '@edtr-io/internal__plugin-state'
+import {
+  AsyncResolver,
+  StateType,
+  Updater
+} from '@edtr-io/internal__plugin-state'
 
 export function boolean(initialValue?: boolean) {
   return scalar<boolean>(initialValue || false)
@@ -26,10 +30,101 @@ export function scalar<S>(initialState: S) {
     }
   })
 }
-// export function asyncSerializedScalar<S, T>(
-//   initialState: T,
-//   serializer: Serializer<S, T>
-// ): StateType<S, T, { value: T, get(): T, set(value:T | (())): void }>
+
+interface Temporary<T> {
+  tmp: T
+}
+
+function isTemporary<T>(field: unknown | Temporary<T>): field is Temporary<T> {
+  return typeof (field as Temporary<T>).tmp !== 'undefined'
+}
+
+export function asyncScalar<S, T, Temp>(
+  initial: AsyncResolver<T | Temporary<Temp>>,
+  serializer: Serializer<S, T | Temporary<Temp>>
+): StateType<
+  S,
+  T | Temporary<Temp>,
+  {
+    value: T | Temporary<Temp>
+    get(): T | Temporary<Temp>
+    set(
+      async: AsyncResolver<
+        | T
+        | Temporary<Temp>
+        | ((previousValue: T | Temporary<Temp>) => T | Temporary<Temp>)
+      >
+    ): void
+    isTemporary(): boolean
+  }
+> {
+  return {
+    init(state, onChange) {
+      return {
+        value: state,
+        get() {
+          return state
+        },
+        set(async) {
+          onChange({
+            immediate: previousState => {
+              if (typeof async.immediate === 'function') {
+                const f = async.immediate as ((
+                  previous: T | Temporary<Temp>
+                ) => T | Temporary<Temp>)
+                return f(previousState)
+              } else {
+                return async.immediate
+              }
+            },
+            ...(async.resolver
+              ? {
+                  resolver: (resolve, reject, next) => {
+                    if (!async.resolver) return
+
+                    async.resolver(
+                      wrapResolverParam(resolve),
+                      wrapResolverParam(reject),
+                      wrapResolverParam(next)
+                    )
+                  }
+                }
+              : {})
+          })
+        },
+        isTemporary() {
+          return isTemporary(state)
+        }
+      }
+      function wrapResolverParam(
+        callback: (updater: Updater<T | Temporary<Temp>>) => void
+      ): (
+        updater:
+          | T
+          | Temporary<Temp>
+          | ((previousValue: T | Temporary<Temp>) => T | Temporary<Temp>)
+      ) => void {
+        return update => {
+          if (typeof update === 'function') {
+            const f = update as ((
+              previous: T | Temporary<Temp>
+            ) => T | Temporary<Temp>)
+            return callback(f)
+          }
+
+          return callback(() => update)
+        }
+      }
+    },
+    createInitialState() {
+      return initial.immediate
+    },
+    getFocusableChildren() {
+      return []
+    },
+    ...serializer
+  }
+}
 
 export function serializedScalar<S, T>(
   initialState: T,
@@ -57,7 +152,7 @@ export function serializedScalar<S, T>(
         }
         public set(param: T | ((previousValue: T) => T)) {
           onChange({
-            immediateState: previousValue => {
+            immediate: previousValue => {
               if (typeof param === 'function') {
                 const updater = param as ((currentValue: T) => T)
                 return updater(previousValue)

--- a/packages/public/plugin/src/scalar.ts
+++ b/packages/public/plugin/src/scalar.ts
@@ -26,6 +26,10 @@ export function scalar<S>(initialState: S) {
     }
   })
 }
+// export function asyncSerializedScalar<S, T>(
+//   initialState: T,
+//   serializer: Serializer<S, T>
+// ): StateType<S, T, { value: T, get(): T, set(value:T | (())): void }>
 
 export function serializedScalar<S, T>(
   initialState: T,
@@ -52,12 +56,14 @@ export function serializedScalar<S, T>(
           return state
         }
         public set(param: T | ((previousValue: T) => T)) {
-          onChange(previousValue => {
-            if (typeof param === 'function') {
-              const updater = param as ((currentValue: T) => T)
-              return updater(previousValue)
+          onChange({
+            immediateState: previousValue => {
+              if (typeof param === 'function') {
+                const updater = param as ((currentValue: T) => T)
+                return updater(previousValue)
+              }
+              return param
             }
-            return param
           })
         }
       }

--- a/packages/public/plugin/src/scalar.ts
+++ b/packages/public/plugin/src/scalar.ts
@@ -33,7 +33,7 @@ export function scalar<S>(initialState: S) {
 
 export function asyncScalar<T, Temp>(
   initial: T,
-  isTemporary: (field: T | Temp) => field is Temp
+  isTemporaryValue: (field: T | Temp) => boolean
 ): StateType<
   T,
   T | Temp,
@@ -45,6 +45,11 @@ export function asyncScalar<T, Temp>(
     ): void
   }
 > {
+  // warp boolean to typeguard
+  function isTemporary(field: T | Temp): field is Temp {
+    return isTemporaryValue(field)
+  }
+
   return {
     init(state, onChange) {
       return {
@@ -66,7 +71,6 @@ export function asyncScalar<T, Temp>(
               ? {
                   resolver: (resolve, reject, next) => {
                     if (!async.resolver) return
-                    console.log('async scalar resolver')
 
                     async.resolver(
                       wrapResolverParam(resolve),

--- a/packages/public/plugin/src/upload.ts
+++ b/packages/public/plugin/src/upload.ts
@@ -51,13 +51,13 @@ export function upload<T>(
               return uploaded
             })
             .catch(reason => {
-              s.value = { failed: file }
+              s.value = { uploadHandled: true, failed: file }
               return Promise.reject(reason)
             })
 
           read.then((loaded: LoadedFile) => {
             if (!uploadFinished) {
-              s.value = { loaded }
+              s.value = { uploadHandled: true, loaded }
             }
           })
 
@@ -98,8 +98,10 @@ export function usePendingFilesUploader<T>(
       if (
         isTempFile(fileState.value) &&
         fileState.value.pending &&
-        !uploading[i]
+        !uploading[i] &&
+        !fileState.value.uploadHandled
       ) {
+        fileState.value.uploadHandled = true
         setUploading(currentUploading => {
           return {
             ...currentUploading,
@@ -131,6 +133,7 @@ export type UploadValidator<E = unknown> = (
 ) => { valid: true } | { valid: false; errors: E }
 
 export interface TempFile {
+  uploadHandled?: boolean
   pending?: File
   failed?: File
   loaded?: LoadedFile

--- a/packages/public/plugin/src/upload.ts
+++ b/packages/public/plugin/src/upload.ts
@@ -5,7 +5,7 @@
 import { StateType } from '@edtr-io/internal__plugin-state'
 import * as React from 'react'
 
-import { serializedScalar } from './scalar'
+import { asyncScalar } from './scalar'
 
 export interface UploadStateReturnType<T> {
   get(): FileState<T>
@@ -20,50 +20,58 @@ export interface UploadStateReturnType<T> {
 export function upload<T>(
   defaultState: T
 ): StateType<FileState<T>, FileState<T>, UploadStateReturnType<T>> {
-  const state = serializedScalar<FileState<T>, FileState<T>>(defaultState, {
-    deserialize(serialized) {
-      return serialized
-    },
-    serialize(deserialized) {
-      if (isTempFile(deserialized)) {
-        return defaultState
-      }
-      return deserialized
-    }
-  })
+  const state = asyncScalar<T, TempFile>(defaultState, isTempFile)
   return {
     ...state,
     init(...args) {
       const s = state.init(...args)
-      return Object.assign(s, {
+      return {
+        ...s,
+        set(
+          value: FileState<T> | ((currentValue: FileState<T>) => FileState<T>)
+        ) {
+          s.set({
+            immediate: value
+          })
+        },
         isPending: isTempFile(s.value) && !!s.value.pending,
         upload(file: File, handler: UploadHandler<T>): Promise<T> {
-          const read = readFile(file)
-          let uploadFinished = false
-
           const uploaded = handler(file)
-            .then(uploaded => {
-              uploadFinished = true
-              return uploaded
-            })
-            .then(uploaded => {
-              s.value = uploaded
-              return uploaded
-            })
-            .catch(reason => {
-              s.value = { uploadHandled: true, failed: file }
-              return Promise.reject(reason)
-            })
+          s.set({
+            immediate: defaultState,
+            resolver: (resolve, reject, next) => {
+              const read = readFile(file)
+              let uploadFinished = false
 
-          read.then((loaded: LoadedFile) => {
-            if (!uploadFinished) {
-              s.value = { uploadHandled: true, loaded }
+              read.then((loaded: LoadedFile) => {
+                if (!uploadFinished) {
+                  next(() => {
+                    return { uploadHandled: true, loaded }
+                  })
+                }
+              })
+
+              uploaded
+                .then(uploaded => {
+                  uploadFinished = true
+                  return uploaded
+                })
+                .then(uploaded => {
+                  resolve(() => {
+                    return uploaded
+                  })
+                })
+                .catch(() => {
+                  reject(() => {
+                    return { uploadHandled: true, failed: file }
+                  })
+                })
             }
           })
 
           return uploaded
         }
-      })
+      }
     }
   }
 }
@@ -92,38 +100,28 @@ export function usePendingFilesUploader<T>(
   files: UploadStateReturnType<T>[],
   uploadHandler: UploadHandler<T>
 ) {
-  const [uploading, setUploading] = React.useState([] as boolean[])
+  const [uploading, setUploading] = React.useState(0)
   React.useEffect(() => {
-    files.forEach((fileState, i) => {
-      if (
-        isTempFile(fileState.value) &&
-        fileState.value.pending &&
-        !uploading[i] &&
-        !fileState.value.uploadHandled
-      ) {
-        fileState.value.uploadHandled = true
-        setUploading(currentUploading => {
-          return {
-            ...currentUploading,
-            [i]: true
-          }
-        })
+    // everything uploaded already
+    if (uploading >= files.length) return
+    const fileState = files[uploading]
 
-        fileState
-          .upload(fileState.value.pending, uploadHandler)
-          .catch(onDone)
-          .then(onDone)
-      }
+    if (
+      isTempFile(fileState.value) &&
+      fileState.value.pending &&
+      !fileState.value.uploadHandled
+    ) {
+      fileState.value.uploadHandled = true
 
-      function onDone() {
-        setUploading(currentUploading => {
-          return {
-            ...currentUploading,
-            [i]: false
-          }
-        })
-      }
-    })
+      fileState
+        .upload(fileState.value.pending, uploadHandler)
+        .catch(onDone)
+        .then(onDone)
+    }
+
+    function onDone() {
+      setUploading(currentUploading => currentUploading + 1)
+    }
   }, [files, uploadHandler, uploading])
 }
 export type UploadHandler<T> = (file: File) => Promise<T>

--- a/packages/public/store/__tests__/documents.ts
+++ b/packages/public/store/__tests__/documents.ts
@@ -130,7 +130,7 @@ describe('Documents', () => {
       store.dispatch(
         S.change({
           id: '1',
-          state: { immediateState: () => 1 }
+          state: { immediate: () => 1 }
         })
       )
       await waitUntil(() =>

--- a/packages/public/store/__tests__/documents.ts
+++ b/packages/public/store/__tests__/documents.ts
@@ -121,7 +121,7 @@ describe('Documents', () => {
       store.dispatch(
         S.change({
           id: '1',
-          state: { immediate: () => 1 }
+          state: { initial: () => 1 }
         })
       )
       await waitUntil(() =>

--- a/packages/public/store/__tests__/documents.ts
+++ b/packages/public/store/__tests__/documents.ts
@@ -27,20 +27,6 @@ describe('Documents', () => {
       expect(doc.plugin).toEqual('text')
     })
 
-    test('Stateless Plugin', async () => {
-      store.dispatch(
-        S.insert({
-          id: '1',
-          plugin: 'stateless'
-        })
-      )
-      await waitUntil(() =>
-        R.any(action => action.type === pureInsert.type, store.getActions())
-      )
-      expect(S.getDocument('1')(store.getState())).toEqual({
-        plugin: 'stateless'
-      })
-    })
     test('Stateful plugin w/ state', async () => {
       store.dispatch(
         S.insert({
@@ -64,7 +50,8 @@ describe('Documents', () => {
       store.dispatch(
         S.insert({
           id: '1',
-          plugin: 'stateless'
+          plugin: 'stateful',
+          state: { counter: 0 }
         })
       )
       await waitUntil(() =>
@@ -77,13 +64,15 @@ describe('Documents', () => {
       store.dispatch(
         S.insert({
           id: '1',
-          plugin: 'stateless'
+          plugin: 'stateful',
+          state: { counter: 0 }
         })
       )
       store.dispatch(
         S.insert({
           id: '2',
-          plugin: 'stateless'
+          plugin: 'stateful',
+          state: { counter: 0 }
         })
       )
       await waitUntil(
@@ -96,7 +85,8 @@ describe('Documents', () => {
       store.dispatch(S.remove('1'))
       expect(getDocuments()(store.getState())).toEqual({
         2: {
-          plugin: 'stateless'
+          plugin: 'stateful',
+          state: { counter: 0 }
         }
       })
     })
@@ -104,7 +94,8 @@ describe('Documents', () => {
       store.dispatch(
         S.insert({
           id: '1',
-          plugin: 'stateless'
+          plugin: 'stateful',
+          state: { counter: 0 }
         })
       )
       await waitUntil(() =>

--- a/packages/public/store/__tests__/documents.ts
+++ b/packages/public/store/__tests__/documents.ts
@@ -130,7 +130,7 @@ describe('Documents', () => {
       store.dispatch(
         S.change({
           id: '1',
-          state: () => 1
+          state: { immediateState: () => 1 }
         })
       )
       await waitUntil(() =>

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -251,7 +251,7 @@ describe('History', () => {
             ])
           }, 300)
         },
-        initialActions: [
+        immediate: [
           {
             action: pureChange({ id: 'root', state: 1 })(TEST_SCOPE),
             reverse: pureChange({ id: 'root', state: 0 })(TEST_SCOPE)
@@ -311,7 +311,7 @@ describe('History', () => {
 
           firstAsyncUpdate()
         },
-        initialActions: [
+        immediate: [
           {
             action: pureChange({ id: 'root', state: 1 })(TEST_SCOPE),
             reverse: pureChange({ id: 'root', state: 0 })(TEST_SCOPE)
@@ -366,7 +366,7 @@ describe('History', () => {
             ])
           }, 300)
         },
-        initialActions: [
+        immediate: [
           {
             action: pureChange({ id: 'root', state: 1 })(TEST_SCOPE),
             reverse: pureChange({ id: 'root', state: 0 })(TEST_SCOPE)

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -47,7 +47,7 @@ describe('History', () => {
   })
 
   test('Changes will be committed to the history', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     expect(S.hasPendingChanges()(store.getState())).toEqual(true)
     const undoStack = getUndoStack()(store.getState())
     expect(undoStack).toHaveLength(1)
@@ -56,24 +56,24 @@ describe('History', () => {
   })
 
   test('Commits will be added to the redo stack after reverting', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await undo()
     expect(getUndoStack()(store.getState())).toHaveLength(0)
     expect(getRedoStack()(store.getState())).toHaveLength(1)
   })
 
   test('Redo stack will be purged after a commit', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await undo()
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(1)
     expect(getRedoStack()(store.getState())).toHaveLength(0)
   })
 
   test('Undo reverts the last committed actions', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -82,8 +82,8 @@ describe('History', () => {
   })
 
   test('Redo replays the last reverted commit', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await undo()
     await redo()
     expect(S.getDocument('root')(store.getState())).toEqual({
@@ -93,11 +93,11 @@ describe('History', () => {
   })
 
   test('Undo keeps order of previous commits', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 3 } })
+    await change({ id: 'root', state: { immediate: () => 3 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -111,11 +111,11 @@ describe('History', () => {
   })
 
   test('Redo keeps order of remaining commits', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 3 } })
+    await change({ id: 'root', state: { immediate: () => 3 } })
     await undo()
     await undo()
     await undo()
@@ -132,10 +132,10 @@ describe('History', () => {
   })
 
   test('Undo keeps order of actions in previous commits', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 3 } })
+    await change({ id: 'root', state: { immediate: () => 3 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -144,10 +144,10 @@ describe('History', () => {
   })
 
   test('Redo keeps order of actions in remaining commits', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
-    await change({ id: 'root', state: { immediateState: () => 3 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 3 } })
     await undo()
     await undo()
     await redo()
@@ -159,22 +159,22 @@ describe('History', () => {
   })
 
   test('Changes in a small time frame will be combined into a single commit', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(1)
   })
 
   test('Changes in a longer time frame will not be combined', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(2)
   })
 
   test('Undo after redo', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     await undo()
     await redo()
     await undo()
@@ -185,7 +185,7 @@ describe('History', () => {
   })
 
   test('Reset after one change', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
     await reset()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -194,8 +194,8 @@ describe('History', () => {
   })
 
   test('Reset after two changes', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     // undoStack: [[1, 2]]
     await reset()
     expect(S.getDocument('root')(store.getState())).toEqual({
@@ -205,8 +205,8 @@ describe('History', () => {
   })
 
   test('Reset after persist and undo', async () => {
-    await change({ id: 'root', state: { immediateState: () => 1 } })
-    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediate: () => 1 } })
+    await change({ id: 'root', state: { immediate: () => 2 } })
     store.dispatch(S.persist())
     await undo()
     await reset()

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -47,7 +47,7 @@ describe('History', () => {
   })
 
   test('Changes will be committed to the history', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     expect(S.hasPendingChanges()(store.getState())).toEqual(true)
     const undoStack = getUndoStack()(store.getState())
     expect(undoStack).toHaveLength(1)
@@ -56,24 +56,24 @@ describe('History', () => {
   })
 
   test('Commits will be added to the redo stack after reverting', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await undo()
     expect(getUndoStack()(store.getState())).toHaveLength(0)
     expect(getRedoStack()(store.getState())).toHaveLength(1)
   })
 
   test('Redo stack will be purged after a commit', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await undo()
-    store.dispatch(S.change({ id: 'root', state: () => 2 }))
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(1)
     expect(getRedoStack()(store.getState())).toHaveLength(0)
   })
 
   test('Undo reverts the last committed actions', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -82,8 +82,8 @@ describe('History', () => {
   })
 
   test('Redo replays the last reverted commit', async () => {
-    await change({ id: 'root', state: () => 1 })
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await undo()
     await redo()
     expect(S.getDocument('root')(store.getState())).toEqual({
@@ -93,11 +93,11 @@ describe('History', () => {
   })
 
   test('Undo keeps order of previous commits', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 3 })
+    await change({ id: 'root', state: { immediateState: () => 3 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -111,11 +111,11 @@ describe('History', () => {
   })
 
   test('Redo keeps order of remaining commits', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 3 })
+    await change({ id: 'root', state: { immediateState: () => 3 } })
     await undo()
     await undo()
     await undo()
@@ -132,10 +132,10 @@ describe('History', () => {
   })
 
   test('Undo keeps order of actions in previous commits', async () => {
-    await change({ id: 'root', state: () => 1 })
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 3 })
+    await change({ id: 'root', state: { immediateState: () => 3 } })
     await undo()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -144,10 +144,10 @@ describe('History', () => {
   })
 
   test('Redo keeps order of actions in remaining commits', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
-    await change({ id: 'root', state: () => 3 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
+    await change({ id: 'root', state: { immediateState: () => 3 } })
     await undo()
     await undo()
     await redo()
@@ -159,22 +159,22 @@ describe('History', () => {
   })
 
   test('Changes in a small time frame will be combined into a single commit', async () => {
-    await change({ id: 'root', state: () => 1 })
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(1)
   })
 
   test('Changes in a longer time frame will not be combined', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     expect(getUndoStack()(store.getState())).toHaveLength(2)
   })
 
   test('Undo after redo', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await wait(1000)
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     await undo()
     await redo()
     await undo()
@@ -185,7 +185,7 @@ describe('History', () => {
   })
 
   test('Reset after one change', async () => {
-    await change({ id: 'root', state: () => 1 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
     await reset()
     expect(S.getDocument('root')(store.getState())).toEqual({
       plugin: 'stateful',
@@ -194,8 +194,8 @@ describe('History', () => {
   })
 
   test('Reset after two changes', async () => {
-    await change({ id: 'root', state: () => 1 })
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     // undoStack: [[1, 2]]
     await reset()
     expect(S.getDocument('root')(store.getState())).toEqual({
@@ -205,8 +205,8 @@ describe('History', () => {
   })
 
   test('Reset after persist and undo', async () => {
-    await change({ id: 'root', state: () => 1 })
-    await change({ id: 'root', state: () => 2 })
+    await change({ id: 'root', state: { immediateState: () => 1 } })
+    await change({ id: 'root', state: { immediateState: () => 2 } })
     store.dispatch(S.persist())
     await undo()
     await reset()
@@ -353,7 +353,6 @@ describe('History', () => {
     })
   })
 
-
   test('Async change with reject', async () => {
     store.dispatch(
       tempCommit({
@@ -387,7 +386,6 @@ describe('History', () => {
     expect(getUndoStack()(store.getState())).toHaveLength(1)
     expect(getUndoStack()(store.getState())[0]).toHaveLength(1)
   })
-
 })
 
 async function undo() {

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -214,6 +214,28 @@ describe('History', () => {
       state: 2
     })
   })
+
+  test('Undo insert', async () => {
+    await insert({ id: '1', plugin: 'stateful', state: 2 })
+    expect(S.getDocument('1')(store.getState())).toEqual({
+      plugin: 'stateful',
+      state: 2
+    })
+    await undo()
+    expect(S.getDocument('1')(store.getState())).toEqual(null)
+  })
+
+  test('Undo remove', async () => {
+    await insert({ id: '1', plugin: 'stateful', state: 2 })
+    await wait(1000)
+    await remove('1')
+    expect(S.getDocument('1')(store.getState())).toEqual(null)
+    await undo()
+    expect(S.getDocument('1')(store.getState())).toEqual({
+      plugin: 'stateful',
+      state: 2
+    })
+  })
 })
 
 async function undo() {
@@ -232,6 +254,20 @@ async function redo() {
 
 async function change(...args: Parameters<typeof S.change>) {
   store.dispatch(S.change(...args))
+  await waitUntil(() =>
+    R.any(action => action.type === commit.type, store.getActions())
+  )
+}
+
+async function insert(...args: Parameters<typeof S.insert>) {
+  store.dispatch(S.insert(...args))
+  await waitUntil(() =>
+    R.any(action => action.type === commit.type, store.getActions())
+  )
+}
+
+async function remove(...args: Parameters<typeof S.remove>) {
+  store.dispatch(S.remove(...args))
   await waitUntil(() =>
     R.any(action => action.type === commit.type, store.getActions())
   )

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -51,7 +51,7 @@ describe('History', () => {
     const undoStack = getUndoStack()(store.getState())
     expect(undoStack).toHaveLength(1)
     expect(undoStack[0]).toHaveLength(1)
-    expect(undoStack[0][0].type).toEqual(pureChange.type)
+    expect(undoStack[0][0].action.type).toEqual(pureChange.type)
   })
 
   test('Commits will be added to the redo stack after reverting', async () => {

--- a/packages/public/store/__tests__/root.ts
+++ b/packages/public/store/__tests__/root.ts
@@ -25,16 +25,6 @@ describe('Root', () => {
   })
 
   describe('Init Root', () => {
-    test('Stateless Plugin', async () => {
-      store.dispatch(initRoot({ plugin: 'stateless' }))
-      await waitUntil(() =>
-        R.any(action => action.type === persist.type, store.getActions())
-      )
-      expect(S.serializeRootDocument()(store.getState())).toEqual({
-        plugin: 'stateless'
-      })
-    })
-
     test('Stateful Plugin', async () => {
       store.dispatch(initRoot({ plugin: 'stateful', state: 0 }))
       await waitUntil(() =>

--- a/packages/public/store/src/actions.ts
+++ b/packages/public/store/src/actions.ts
@@ -26,7 +26,7 @@ export type Action =
 
 export interface Reversible<A = unknown, R = unknown> {
   action: A
-  reverse?: R
+  reverse: R
 }
 
 export type ReversibleAction<

--- a/packages/public/store/src/actions.ts
+++ b/packages/public/store/src/actions.ts
@@ -2,6 +2,8 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
+import { Action as ReduxAction } from 'redux'
+
 import { ClipboardAction } from './clipboard/actions'
 import { DocumentsAction } from './documents/actions'
 import { FocusAction } from './focus/actions'
@@ -24,7 +26,7 @@ export type Action =
   | RootAction
   | SetPartialState
 
-export interface Reversible<A = unknown, R = unknown> {
+export interface Reversible<A = ReduxAction, R = ReduxAction> {
   action: A
   reverse: R
 }

--- a/packages/public/store/src/actions.ts
+++ b/packages/public/store/src/actions.ts
@@ -23,3 +23,13 @@ export type Action =
   | HistoryAction
   | RootAction
   | SetPartialState
+
+export interface Reversible<A = unknown, R = unknown> {
+  action: A
+  reverse?: R
+}
+
+export type ReversibleAction<
+  A extends Action = Action,
+  R extends Action = Action
+> = Reversible<A, R>

--- a/packages/public/store/src/documents/actions.ts
+++ b/packages/public/store/src/documents/actions.ts
@@ -2,7 +2,7 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { StateUpdater, StoreDeserializeHelpers } from '@edtr-io/internal__plugin-state'
+import { StateUpdater } from '@edtr-io/internal__plugin-state'
 
 import { createAction } from '../helpers'
 import { ActionFromActionCreator, DocumentState } from '../types'

--- a/packages/public/store/src/documents/actions.ts
+++ b/packages/public/store/src/documents/actions.ts
@@ -27,6 +27,9 @@ export type PureInsertAction = ActionFromActionCreator<typeof pureInsert>
 export const remove = createAction<'Remove', string>('Remove')
 export type RemoveAction = ActionFromActionCreator<typeof remove>
 
+export const pureRemove = createAction<'PureRemove', string>('PureRemove')
+export type PureRemoveAction = ActionFromActionCreator<typeof pureRemove>
+
 export const change = createAction<
   'Change',
   {
@@ -45,5 +48,6 @@ export type DocumentsAction =
   | InsertAction
   | PureInsertAction
   | RemoveAction
-  | PureChangeAction
+  | PureRemoveAction
   | ChangeAction
+  | PureChangeAction

--- a/packages/public/store/src/documents/actions.ts
+++ b/packages/public/store/src/documents/actions.ts
@@ -2,7 +2,7 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { StateUpdater } from '@edtr-io/internal__plugin-state'
+import { StateExecutor, StateUpdater } from '@edtr-io/internal__plugin-state'
 
 import { createAction } from '../helpers'
 import { ActionFromActionCreator, DocumentState } from '../types'
@@ -34,7 +34,10 @@ export const change = createAction<
   'Change',
   {
     id: string
-    state: StateUpdater<unknown>
+    state: {
+      initial: StateUpdater<unknown>
+      executor?: StateExecutor<StateUpdater<unknown>>
+    }
   }
 >('Change')
 export type ChangeAction = ActionFromActionCreator<typeof change>

--- a/packages/public/store/src/documents/actions.ts
+++ b/packages/public/store/src/documents/actions.ts
@@ -2,7 +2,7 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { StoreDeserializeHelpers } from '@edtr-io/internal__plugin-state'
+import { StateUpdater, StoreDeserializeHelpers } from '@edtr-io/internal__plugin-state'
 
 import { createAction } from '../helpers'
 import { ActionFromActionCreator, DocumentState } from '../types'
@@ -34,7 +34,7 @@ export const change = createAction<
   'Change',
   {
     id: string
-    state: (value: unknown, helpers: StoreDeserializeHelpers) => unknown
+    state: StateUpdater<unknown>
   }
 >('Change')
 export type ChangeAction = ActionFromActionCreator<typeof change>

--- a/packages/public/store/src/documents/reducer.ts
+++ b/packages/public/store/src/documents/reducer.ts
@@ -16,10 +16,10 @@ import { DocumentState } from '../types'
 import {
   pureInsert,
   PureInsertAction,
-  remove,
   RemoveAction,
   pureChange,
-  PureChangeAction
+  PureChangeAction,
+  pureRemove
 } from './actions'
 
 export const documentsReducer = createSubReducer(
@@ -39,7 +39,7 @@ export const documentsReducer = createSubReducer(
         }
       }
     },
-    [remove.type](documentState, action: RemoveAction) {
+    [pureRemove.type](documentState, action: RemoveAction) {
       return R.omit([action.payload], documentState)
     },
     [pureChange.type](documentState, action: PureChangeAction) {

--- a/packages/public/store/src/documents/reducer.ts
+++ b/packages/public/store/src/documents/reducer.ts
@@ -2,11 +2,7 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import {
-  isStatefulPlugin,
-  isStatelessPlugin,
-  Plugin
-} from '@edtr-io/internal__plugin'
+import { Plugin } from '@edtr-io/internal__plugin'
 import { StoreSerializeHelpers } from '@edtr-io/internal__plugin-state'
 import * as R from 'ramda'
 
@@ -35,7 +31,7 @@ export const documentsReducer = createSubReducer(
         ...documentState,
         [id]: {
           plugin: type,
-          state: isStatefulPlugin(plugin) ? pluginState : undefined
+          state: pluginState
         }
       }
     },
@@ -74,9 +70,7 @@ export const serializeDocument = createSelector((state, id: string | null) => {
   }
   return {
     plugin: doc.plugin,
-    ...(isStatelessPlugin(plugin)
-      ? {}
-      : { state: plugin.state.serialize(doc.state, serializeHelpers) })
+    state: plugin.state.serialize(doc.state, serializeHelpers)
   }
 })
 
@@ -91,7 +85,7 @@ export function isDocumentEmpty(
   doc: DocumentState | null,
   plugin: Plugin | null
 ) {
-  if (!doc || !plugin || isStatelessPlugin(plugin)) return false
+  if (!doc || !plugin) return false
 
   if (typeof plugin.isEmpty === 'function') {
     return plugin.isEmpty(doc.state)

--- a/packages/public/store/src/documents/saga.ts
+++ b/packages/public/store/src/documents/saga.ts
@@ -2,7 +2,6 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { isStatefulPlugin } from '@edtr-io/internal__plugin'
 import {
   StoreDeserializeHelpers,
   Updater
@@ -213,12 +212,10 @@ export function* handleRecursiveInserts(
     if (!plugin) return
 
     let pluginState: unknown
-    if (isStatefulPlugin(plugin)) {
-      if (doc.state === undefined) {
-        pluginState = plugin.state.createInitialState(helpers)
-      } else {
-        pluginState = plugin.state.deserialize(doc.state, helpers)
-      }
+    if (doc.state === undefined) {
+      pluginState = plugin.state.createInitialState(helpers)
+    } else {
+      pluginState = plugin.state.deserialize(doc.state, helpers)
     }
 
     const pluginType: ReturnTypeFromSelector<

--- a/packages/public/store/src/documents/saga.ts
+++ b/packages/public/store/src/documents/saga.ts
@@ -81,7 +81,7 @@ function* changeSaga(action: ChangeAction) {
     handleRecursiveInserts,
     action.scope,
     (helpers: StoreDeserializeHelpers) => {
-      return stateHandler.immediateState(document.state, helpers)
+      return stateHandler.immediate(document.state, helpers)
     }
   )
 
@@ -106,7 +106,7 @@ function* changeSaga(action: ChangeAction) {
 
     yield put(
       tempCommit({
-        initialActions: actions,
+        immediate: actions,
         resolver: (resolve, reject, next) => {
           if (!stateHandler.resolver) {
             resolve(actions)

--- a/packages/public/store/src/documents/saga.ts
+++ b/packages/public/store/src/documents/saga.ts
@@ -157,12 +157,10 @@ function* changeSaga(action: ChangeAction) {
     while (true) {
       const payload: ChannelAction = yield take(chan)
 
-      console.log('channel action', payload)
       const currentDocument: ReturnTypeFromSelector<
         typeof getDocument
       > = yield select(scopeSelector(getDocument, action.scope), id)
       if (!currentDocument) continue
-      console.log(currentDocument)
 
       const updater =
         payload.resolve || payload.next || payload.reject || (s => s)

--- a/packages/public/store/src/documents/saga.ts
+++ b/packages/public/store/src/documents/saga.ts
@@ -157,6 +157,13 @@ function* changeSaga(action: ChangeAction) {
     while (true) {
       const payload: ChannelAction = yield take(chan)
 
+      console.log('channel action', payload)
+      const currentDocument: ReturnTypeFromSelector<
+        typeof getDocument
+      > = yield select(scopeSelector(getDocument, action.scope), id)
+      if (!currentDocument) continue
+      console.log(currentDocument)
+
       const updater =
         payload.resolve || payload.next || payload.reject || (s => s)
 
@@ -167,7 +174,7 @@ function* changeSaga(action: ChangeAction) {
         handleRecursiveInserts,
         action.scope,
         (helpers: StoreDeserializeHelpers) => {
-          return updater(document.state, helpers)
+          return updater(currentDocument.state, helpers)
         }
       )
       payload.callback(resolveActions, pureResolveState)

--- a/packages/public/store/src/focus/reducer.ts
+++ b/packages/public/store/src/focus/reducer.ts
@@ -2,7 +2,6 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { isStatefulPlugin } from '@edtr-io/internal__plugin'
 import * as R from 'ramda'
 
 import { pureInsert, PureInsertAction } from '../documents/actions'
@@ -70,15 +69,12 @@ export const getFocusTree: Selector<Node | null, [string?]> = createSelector(
     const plugin = getPlugin(document.plugin)(state)
     if (!plugin) return null
 
-    let children
-    if (isStatefulPlugin(plugin)) {
-      children = plugin.state
-        .getFocusableChildren(document.state)
-        .map(child => {
-          const subtree = getFocusTree(child.id)(state)
-          return subtree || child
-        })
-    }
+    const children = plugin.state
+      .getFocusableChildren(document.state)
+      .map(child => {
+        const subtree = getFocusTree(child.id)(state)
+        return subtree || child
+      })
 
     return {
       id: root,

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -2,6 +2,8 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
+import { AsyncResolver } from '@edtr-io/internal__plugin-state'
+
 import { Reversible } from '../actions'
 import { createAction, createActionWithoutPayload } from '../helpers'
 import { ActionFromActionCreator } from '../types'
@@ -28,14 +30,7 @@ export type PureCommitAction = ActionFromActionCreator<typeof pureCommit>
 
 export const tempCommit = createAction<
   'TempCommitAction',
-  {
-    resolver: (
-      resolve: (actions: Reversible[]) => void,
-      reject: (actions: Reversible[]) => void,
-      next: (actions: Reversible[]) => void
-    ) => void
-    initialActions: Reversible[]
-  }
+  AsyncResolver<Reversible[]>
 >('TempCommitAction')
 export type TempCommitAction = ActionFromActionCreator<typeof tempCommit>
 

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -2,9 +2,9 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
+import { Reversible } from '../actions'
 import { createAction, createActionWithoutPayload } from '../helpers'
 import { ActionFromActionCreator } from '../types'
-import { Reversible } from '../actions'
 
 export const persist = createActionWithoutPayload<'Persist'>('Persist')
 export type PersistAction = ActionFromActionCreator<typeof persist>

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -26,10 +26,17 @@ export const pureCommit = createAction<
 >('PureCommit')
 export type PureCommitAction = ActionFromActionCreator<typeof pureCommit>
 
-export const tempCommit = createAction<'TempCommitAction', {
-  resolver: (resolve: (actions: Reversible[]) => void, reject: Function, next: (actions: Reversible[]) => void) => void
-  initialActions: Reversible[]
-}>('TempCommitAction')
+export const tempCommit = createAction<
+  'TempCommitAction',
+  {
+    resolver: (
+      resolve: (actions: Reversible[]) => void,
+      reject: (actions: Reversible[]) => void,
+      next: (actions: Reversible[]) => void
+    ) => void
+    initialActions: Reversible[]
+  }
+>('TempCommitAction')
 export type TempCommitAction = ActionFromActionCreator<typeof tempCommit>
 
 export const undo = createActionWithoutPayload<'Undo'>('Undo')

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -4,6 +4,7 @@
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import { createAction, createActionWithoutPayload } from '../helpers'
 import { ActionFromActionCreator } from '../types'
+import { Reversible } from '../actions'
 
 export const persist = createActionWithoutPayload<'Persist'>('Persist')
 export type PersistAction = ActionFromActionCreator<typeof persist>
@@ -13,14 +14,14 @@ export type ResetAction = ActionFromActionCreator<typeof reset>
 export const pureReset = createActionWithoutPayload<'PureReset'>('PureReset')
 export type PureResetAction = ActionFromActionCreator<typeof pureReset>
 
-// Accepts an array of `Action`s as payload. This would lead to a reference cycle, though
-export const commit = createAction<'Commit', unknown[]>('Commit')
+// Actually accepts an array of `ReversibleAction`s as payload. This would lead to a reference cycle, though
+export const commit = createAction<'Commit', Reversible[]>('Commit')
 export type CommitAction = ActionFromActionCreator<typeof commit>
 export const pureCommit = createAction<
   'PureCommit',
   {
     combine: boolean
-    actions: unknown[]
+    actions: Reversible[]
   }
 >('PureCommit')
 export type PureCommitAction = ActionFromActionCreator<typeof pureCommit>

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -26,6 +26,12 @@ export const pureCommit = createAction<
 >('PureCommit')
 export type PureCommitAction = ActionFromActionCreator<typeof pureCommit>
 
+export const tempCommit = createAction<'TempCommitAction', {
+  resolver: (resolve: (actions: Reversible[]) => void, reject: Function, next: (actions: Reversible[]) => void) => void
+  initialActions: Reversible[]
+}>('TempCommitAction')
+export type TempCommitAction = ActionFromActionCreator<typeof tempCommit>
+
 export const undo = createActionWithoutPayload<'Undo'>('Undo')
 export type UndoAction = ActionFromActionCreator<typeof undo>
 export const pureUndo = createActionWithoutPayload<'PureUndo'>('PureUndo')
@@ -46,3 +52,4 @@ export type HistoryAction =
   | PureUndoAction
   | RedoAction
   | PureRedoAction
+  | TempCommitAction

--- a/packages/public/store/src/history/actions.ts
+++ b/packages/public/store/src/history/actions.ts
@@ -2,7 +2,7 @@
  * @module @edtr-io/store
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
-import { AsyncResolver } from '@edtr-io/internal__plugin-state'
+import { StateExecutor } from '@edtr-io/internal__plugin-state'
 
 import { Reversible } from '../actions'
 import { createAction, createActionWithoutPayload } from '../helpers'
@@ -28,11 +28,16 @@ export const pureCommit = createAction<
 >('PureCommit')
 export type PureCommitAction = ActionFromActionCreator<typeof pureCommit>
 
-export const tempCommit = createAction<
-  'TempCommitAction',
-  AsyncResolver<Reversible[]>
->('TempCommitAction')
-export type TempCommitAction = ActionFromActionCreator<typeof tempCommit>
+export const temporaryCommit = createAction<
+  'TemporaryCommit',
+  {
+    initial: Reversible[]
+    executor?: StateExecutor<Reversible[]>
+  }
+>('TemporaryCommit')
+export type TemporaryCommitAction = ActionFromActionCreator<
+  typeof temporaryCommit
+>
 
 export const undo = createActionWithoutPayload<'Undo'>('Undo')
 export type UndoAction = ActionFromActionCreator<typeof undo>
@@ -54,4 +59,4 @@ export type HistoryAction =
   | PureUndoAction
   | RedoAction
   | PureRedoAction
-  | TempCommitAction
+  | TemporaryCommitAction

--- a/packages/public/store/src/history/reducer.ts
+++ b/packages/public/store/src/history/reducer.ts
@@ -4,7 +4,7 @@
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import * as R from 'ramda'
 
-import { Action } from '../actions'
+import { Action, ReversibleAction } from '../actions'
 import { getDocuments } from '../documents/reducer'
 import { createSelector, createSubReducer } from '../helpers'
 import {
@@ -96,8 +96,8 @@ export const hasPendingChanges = createSelector(
 )
 
 export const getUndoStack = createSelector(
-  state => getHistory()(state).undoStack as Action[][]
+  state => getHistory()(state).undoStack as ReversibleAction[][]
 )
 export const getRedoStack = createSelector(
-  state => getHistory()(state).redoStack as Action[][]
+  state => getHistory()(state).redoStack as ReversibleAction[][]
 )

--- a/packages/public/store/src/history/reducer.ts
+++ b/packages/public/store/src/history/reducer.ts
@@ -4,7 +4,7 @@
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import * as R from 'ramda'
 
-import { Action, ReversibleAction } from '../actions'
+import { ReversibleAction } from '../actions'
 import { getDocuments } from '../documents/reducer'
 import { createSelector, createSubReducer } from '../helpers'
 import {

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -65,12 +65,14 @@ function* tempCommitSaga(action: TempCommitAction) {
       })
     }
   }
-  action.payload.resolver(
-    createPutToChannel('resolve'),
-    createPutToChannel('reject'),
-    createPutToChannel('next')
-  )
-  yield call(resolveSaga, chan)
+  if (action.payload.resolver) {
+    action.payload.resolver(
+      createPutToChannel('resolve'),
+      createPutToChannel('reject'),
+      createPutToChannel('next')
+    )
+    yield call(resolveSaga, chan)
+  }
 }
 
 interface ChannelAction {

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -46,7 +46,7 @@ export function* historySaga() {
 }
 
 function* tempCommitSaga(action: TempCommitAction) {
-  const actions = action.payload.initialActions as ReversibleAction[]
+  const actions = action.payload.immediate as ReversibleAction[]
   yield all(actions.map(action => put(action.action)))
   yield put(
     pureCommit({

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -102,7 +102,7 @@ function* resolveSaga(chan: Channel<ChannelAction>) {
     yield all(tempActions.map(a => put(a.reverse)))
 
     //apply final actions and all reverted actions
-    yield all((finalActions as ReversibleAction[]).map(a => put(a.action)))
+    yield all(finalActions.map(a => put(a.action)))
 
     yield all(
       replays.map(replay => {

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -30,23 +30,23 @@ import {
   UndoAction,
   RedoAction,
   ResetAction,
-  tempCommit,
-  TempCommitAction
+  temporaryCommit,
+  TemporaryCommitAction
 } from './actions'
 import { getPendingChanges, getRedoStack, getUndoStack } from './reducer'
 
 export function* historySaga() {
   yield all([
     call(commitSaga),
-    takeEvery(tempCommit.type, tempCommitSaga),
+    takeEvery(temporaryCommit.type, temporaryCommitSaga),
     takeEvery(undo.type, undoSaga),
     takeEvery(redo.type, redoSaga),
     takeEvery(reset.type, resetSaga)
   ])
 }
 
-function* tempCommitSaga(action: TempCommitAction) {
-  const actions = action.payload.immediate as ReversibleAction[]
+function* temporaryCommitSaga(action: TemporaryCommitAction) {
+  const actions = action.payload.initial as ReversibleAction[]
   yield all(actions.map(action => put(action.action)))
   yield put(
     pureCommit({
@@ -65,8 +65,8 @@ function* tempCommitSaga(action: TempCommitAction) {
       })
     }
   }
-  if (action.payload.resolver) {
-    action.payload.resolver(
+  if (action.payload.executor) {
+    action.payload.executor(
       createPutToChannel('resolve'),
       createPutToChannel('reject'),
       createPutToChannel('next')

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -84,12 +84,7 @@ function* undoSaga(action: UndoAction) {
   const toUndo = R.head(undoStack)
   if (!toUndo) return
   yield all(
-    R.reverse(toUndo)
-      .filter(reversibleAction => !!reversibleAction.reverse)
-      .map(reversibleAction => {
-        if (!reversibleAction.reverse) return
-        return put(reversibleAction.reverse)
-      })
+    R.reverse(toUndo).map(reversibleAction => put(reversibleAction.reverse))
   )
   yield put(pureUndo()(action.scope))
 }

--- a/packages/public/store/src/history/saga.ts
+++ b/packages/public/store/src/history/saga.ts
@@ -3,6 +3,7 @@
  */
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import * as R from 'ramda'
+import { channel, Channel } from 'redux-saga'
 import {
   all,
   call,
@@ -13,7 +14,6 @@ import {
   take,
   takeEvery
 } from 'redux-saga/effects'
-import { channel, Channel } from 'redux-saga'
 
 import { Reversible, ReversibleAction } from '../actions'
 import { scopeSelector } from '../helpers'

--- a/packages/public/store/src/root/saga.ts
+++ b/packages/public/store/src/root/saga.ts
@@ -4,7 +4,7 @@
 /** Comment needed because of https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/337 */
 import { all, call, put, takeEvery } from 'redux-saga/effects'
 
-import { Action, setPartialState } from '../actions'
+import { ReversibleAction, setPartialState } from '../actions'
 import { handleRecursiveInserts } from '../documents/saga'
 import { persist } from '../history/actions'
 import { InitRootAction, initRoot, pureInitRoot } from './actions'
@@ -23,13 +23,13 @@ function* initRootSaga(action: InitRootAction) {
     })(action.scope)
   )
   yield put(pureInitRoot()(action.scope))
-  const [actions]: [Action[], unknown] = yield call(
+  const [actions]: [ReversibleAction[], unknown] = yield call(
     handleRecursiveInserts,
     action.scope,
     () => {},
     [{ id: 'root', ...(action.payload.initialState || {}) }]
   )
 
-  yield all(actions.map(action => put(action)))
+  yield all(actions.map(reversible => put(reversible.action)))
   yield put(persist()(action.scope))
 }

--- a/packages/public/store/src/types.ts
+++ b/packages/public/store/src/types.ts
@@ -5,7 +5,7 @@
 import { Plugin } from '@edtr-io/internal__plugin'
 import { Store as ReduxStore } from 'redux'
 
-import { Action } from './actions'
+import { Action, Reversible } from './actions'
 
 /**
  * Store state
@@ -34,8 +34,8 @@ export interface HistoryState {
   initialState?: {
     documents: ScopedState['documents']
   }
-  undoStack: unknown[][]
-  redoStack: unknown[][]
+  undoStack: Reversible[][]
+  redoStack: Reversible[][]
   pendingChanges: number
 }
 

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -475,7 +475,7 @@ const state = string()
         '**core**. Moved all store exports (e.g. `createStore`) to the new package `@edtr-io/store`'
       ],
       added: [
-        '**plugin**. Published new package `@edtr-io/plugin` intended to be used by plugin authors. It exposes `Plugin`, `StatefulPluginEditorProps`, `StatelessPluginEditorProps`, `StatefulPlugin`, `StatelessPlugin` and (flatly) everything that was previously exported as `StateType`.',
+        '**plugin**. Published new package `@edtr-io/plugin` intended to be used by plugin authors. It exposes `Plugin`, `PluginEditorProps`, `StatelessPluginEditorProps`, `StatefulPlugin`, `StatelessPlugin` and (flatly) everything that was previously exported as `StateType`.',
         '**store**. Published new package `@edtr-io/store`. It (flatly) exposes actions and selectors, and all previous store exports that are mostly for special use cases.'
       ],
       changed: [
@@ -528,7 +528,7 @@ useScopedSelector(state => {
       breakingChanges: [
         '**plugin**. Refactored `StateType` API. This should only affect you if you defined custom state types.',
         '**plugin**. Consistently renamed `StateDescriptor*` types to `StateType*`',
-        '**plugin**. `StatelessPluginEditorProps` and `StatefulPluginEditorProps` no longer accept the type param `Props`. Replace `StatelessPluginEditorProps<Props>` with `StatelessPluginEditorProps & Props`.',
+        '**plugin**. `StatelessPluginEditorProps` and `PluginEditorProps` no longer accept the type param `Props`. Replace `StatelessPluginEditorProps<Props>` with `StatelessPluginEditorProps & Props`.',
         '**plugin**. `StatelessPlugin` may no longer define `getFocusableChildren`. This is handled by state types instead.',
         '**plugin**. The return type of the built-in `child` state type is no longer callable. Replace `state()` with `state.get()` or `state.id` to retrieve the `id`.',
         "**plugin**. The return type of the built-in `list` state type is no longer callable and doesn't expose `items` anymore. Instead, the return types behaves like an array itself. Replace `state()` resp. `state.items` with `state`.",


### PR DESCRIPTION
### Fixed
- **plugin**. Prevent reupload of pending files in the state type `upload` on undo/redo
- Performance improvement for undo/redo: Instead of building the state from ground up using the actions, now comited action is reversible itself
- **plugin-image**, **plugin-files**: drag&drop upload fixed - closes #237 

### Breaking Changes
- API of `getUndoStack` and `getRedoStack` changed: Previously `Action[][]` now, `ReversibleAction[][] = { action: Action, reverse?: Action }[][]`
- Removed types `StatelessPlugin`, `StatelessPluginProps` and type guards `isStatelessPlugin` and `isStatefulPlugin`. Renamed type `StatefulPlugin` to type `Plugin` and `StatefulPluginEditorProps` to `PluginEditorProps`