### PR TITLE
fix: show toolbar if renderIntoToolbar was called somewhere

### DIFF
--- a/packages/private/demo/__stories__/toolbar.tsx
+++ b/packages/private/demo/__stories__/toolbar.tsx
@@ -1,6 +1,5 @@
 import { PluginToolbarButton } from '@edtr-io/core'
-import { EditorPlugin } from '@edtr-io/internal__plugin'
-import { number } from '@edtr-io/plugin'
+import { EditorPlugin, number } from '@edtr-io/plugin'
 import { styled } from '@edtr-io/ui'
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'

--- a/packages/private/demo/__stories__/toolbar.tsx
+++ b/packages/private/demo/__stories__/toolbar.tsx
@@ -1,0 +1,60 @@
+import { PluginToolbarButton } from '@edtr-io/core'
+import { EditorPlugin } from '@edtr-io/internal__plugin'
+import { number } from '@edtr-io/plugin'
+import { styled } from '@edtr-io/ui'
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+
+import { EditorStory } from '../src'
+
+const state = {
+  plugin: 'counter',
+  state: 0
+}
+
+const ToolbarIcon = styled.div({
+  backgroundColor: '#aaa',
+  width: '20px',
+  borderRadius: '3px',
+  margin: '2px'
+})
+
+const counterState = number()
+const counterPlugin: EditorPlugin<typeof counterState> = {
+  Component: function Counter(props) {
+    return (
+      <div>
+        Counter: {props.state.value}
+        {props.renderIntoToolbar(
+          <React.Fragment>
+            <PluginToolbarButton
+              icon={<ToolbarIcon>+</ToolbarIcon>}
+              onClick={() => props.state.set(val => val + 1)}
+              label="Increment"
+            />
+            <PluginToolbarButton
+              icon={<ToolbarIcon>-</ToolbarIcon>}
+              onClick={() => props.state.set(val => val - 1)}
+              label="Decrement"
+            />
+          </React.Fragment>
+        )}
+      </div>
+    )
+  },
+  state: counterState,
+  config: {}
+}
+
+storiesOf('Toolbar', module).add('Plugin with renderIntoToolbar', () => {
+  return (
+    <EditorStory
+      plugins={{
+        counter: counterPlugin
+      }}
+      initialState={state}
+      onChange={action('changed')}
+    />
+  )
+})

--- a/packages/private/demo/package.json
+++ b/packages/private/demo/package.json
@@ -36,6 +36,7 @@
     "@edtr-io/renderer": "^0.13.1",
     "@edtr-io/store": "^0.13.1",
     "@edtr-io/store-devtools": "^0.13.0",
+    "@edtr-io/ui": "^0.13.0",
     "katex": "^0.11.0",
     "lodash": "^4.0.0",
     "lodash-es": "^4.0.0",

--- a/packages/private/document-editor/src/index.ts
+++ b/packages/private/document-editor/src/index.ts
@@ -26,6 +26,11 @@ export interface DocumentEditorProps {
   hasSettings: boolean
 
   /**
+   * `true` if the document has rendered any toolbar buttons
+   */
+  hasToolbar: boolean
+
+  /**
    * Render prop to override rendering of settings
    *
    * @param children - the rendered settings

--- a/packages/public/core/package.json
+++ b/packages/public/core/package.json
@@ -32,6 +32,7 @@
     "shortid": "^2.0.0"
   },
   "devDependencies": {
+    "@edtr-io/internal__fixtures": "^0.13.0",
     "@types/react-test-renderer": "^16.8.0",
     "react": "^16.8.0",
     "react-dnd": "^10.0.0",

--- a/packages/public/core/src/document/editor.tsx
+++ b/packages/public/core/src/document/editor.tsx
@@ -29,6 +29,7 @@ const StyledDocument = styled.div({
 
 export function DocumentEditor({ id, pluginProps }: DocumentProps) {
   const [hasSettings, setHasSettings] = React.useState(false)
+  const [hasToolbar, setHasToolbar] = React.useState(false)
   const document = useScopedSelector(getDocument(id))
   const focused = useScopedSelector(isFocused(id))
   const plugin = useScopedSelector(
@@ -115,6 +116,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
 
   const renderIntoToolbar = React.useCallback(
     (children: React.ReactNode) => {
+      setHasToolbar(true)
       if (!toolbarRef.current) return null
       return createPortal(children, toolbarRef.current)
     },
@@ -210,6 +212,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
         >
           <DocumentEditor
             hasSettings={hasSettings}
+            hasToolbar={hasToolbar}
             focused={focused}
             renderSettings={pluginProps && pluginProps.renderSettings}
             renderToolbar={pluginProps && pluginProps.renderToolbar}
@@ -240,6 +243,7 @@ export function DocumentEditor({ id, pluginProps }: DocumentProps) {
     pluginProps,
     handleFocus,
     hasSettings,
+    hasToolbar,
     focused,
     PluginToolbar,
     renderIntoSettings,

--- a/packages/public/default-document-editor/src/index.tsx
+++ b/packages/public/default-document-editor/src/index.tsx
@@ -86,6 +86,7 @@ export function createDefaultDocumentEditor(
     settingsRef,
     toolbarRef,
     hasSettings,
+    hasToolbar,
     PluginToolbar
   }: DocumentEditorProps) {
     const { OverlayButton, PluginToolbarOverlayButton } = PluginToolbar
@@ -168,7 +169,7 @@ export function createDefaultDocumentEditor(
     }
 
     function showToolbar(): boolean {
-      return renderToolbar !== undefined
+      return hasToolbar || renderToolbar !== undefined
     }
   }
 }

--- a/packages/public/default-document-editor/src/index.tsx
+++ b/packages/public/default-document-editor/src/index.tsx
@@ -97,7 +97,7 @@ export function createDefaultDocumentEditor(
     })
 
     const renderSettingsContent = React.useMemo<typeof renderSettings>(() => {
-      return renderSettings
+      return showSettings()
         ? (children, { close }) => {
             return (
               <React.Fragment>
@@ -112,12 +112,14 @@ export function createDefaultDocumentEditor(
                     <EdtrIcon icon={edtrClose} />
                   </BorderlessOverlayButton>
                 </Header>
-                {renderSettings(children, { close })}
+                {renderSettings
+                  ? renderSettings(children, { close })
+                  : children}
               </React.Fragment>
             )
           }
         : undefined
-    }, [renderSettings])
+    }, [renderSettings, showSettings()])
     const expanded = focused && (showSettings() || showToolbar())
 
     const appended = React.useRef(false)

--- a/packages/public/default-document-editor/src/index.tsx
+++ b/packages/public/default-document-editor/src/index.tsx
@@ -119,7 +119,7 @@ export function createDefaultDocumentEditor(
             )
           }
         : undefined
-    }, [renderSettings, showSettings()])
+    }, [renderSettings, showSettings])
     const expanded = focused && (showSettings() || showToolbar())
 
     const appended = React.useRef(false)

--- a/packages/public/renderer-ssr/package.json
+++ b/packages/public/renderer-ssr/package.json
@@ -18,6 +18,7 @@
     "@types/styled-components": "^4.0.0"
   },
   "devDependencies": {
+    "@edtr-io/internal__fixtures": "^0.13.0",
     "@edtr-io/plugin": "^0.13.1",
     "@edtr-io/plugin-anchor": "^0.13.1",
     "@edtr-io/plugin-blockquote": "^0.13.1",


### PR DESCRIPTION
### Fixed
- **default-document-editor**. Show toolbar if `renderIntoToolbar` was called somewhere
- **default-document-editor**. Show default settings menu if `renderIntoSettings` was called somewhere
