### PR TITLE
eslint: Proper configuration for monorepo

### DIFF
--- a/.eslint-ci.config.js
+++ b/.eslint-ci.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 module.exports = {
   extends: [
     './.eslintrc.js',
@@ -21,12 +24,14 @@ module.exports = {
       'error',
       {
         devDependencies: [
+          'jest*.[jt]s',
           'packages/*/*/{__helpers__,__stories__,__tests__,__tests-ssr__}/**/*',
           'packages/private/bundle-size/webpack.config.js',
           'packages/private/demo/{scripts,src}/**/*',
           'scripts/**/*',
         ],
         optionalDependencies: false,
+        packageDir: [__dirname, ...getPackageDirectories()],
       },
     ],
     'import/no-internal-modules': [
@@ -65,4 +70,18 @@ module.exports = {
       },
     ],
   },
+}
+
+function getPackageDirectories() {
+  const dirs = getDirectories(path.join(__dirname, 'packages'))
+  const dirsOfDirs = dirs.map((dir) => getDirectories(dir))
+
+  return [].concat(...dirsOfDirs)
+}
+
+function getDirectories(source) {
+  return fs
+    .readdirSync(source, { withFileTypes: true })
+    .filter((child) => child.isDirectory())
+    .map((dir) => path.join(source, dir.name))
 }

--- a/packages/private/fixtures/src/plugins.tsx
+++ b/packages/private/fixtures/src/plugins.tsx
@@ -1,5 +1,3 @@
-// Declaring these as devDependencies would lead to a dependency cycles. Since we only use these for testing anyways, we can safely disable the ESLint rule here
-/* eslint-disable import/no-extraneous-dependencies */
 import { child, EditorPlugin, list, number, object } from '@edtr-io/plugin'
 import { plugin as anchorPlugin } from '@edtr-io/plugin-anchor/__fixtures__'
 import { plugin as blockquotePlugin } from '@edtr-io/plugin-blockquote/__fixtures__'


### PR DESCRIPTION
Add the following configurations to the eslint rule `import/no-extraneous-dependencies`:

* all `jest*` files are considered to be files used only in development.
* check looks for all `package.json` files (see option `packageDir` in https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md)