### PR TITLE
Add hasRedoActions() and hasUndoActions()

### DIFF
--- a/api/store.api.md
+++ b/api/store.api.md
@@ -527,7 +527,11 @@ export interface ScopedState {
     // (undocumented)
     focus: string | null;
     // (undocumented)
-    history: unknown;
+    history: {
+        undoStack: unknown[];
+        redoStack: unknown[];
+        pendingChanges: number;
+    };
     // (undocumented)
     plugins: Record<string, EditorPlugin>;
     // (undocumented)

--- a/api/store.api.md
+++ b/api/store.api.md
@@ -223,6 +223,12 @@ export const hasFocusedDescendant: Selector<boolean, [string]>;
 export const hasPendingChanges: Selector<boolean>;
 
 // @public (undocumented)
+export const hasRedoActions: Selector<boolean>;
+
+// @public (undocumented)
+export const hasUndoActions: Selector<boolean>;
+
+// @public (undocumented)
 export type HistoryAction = PersistAction | ResetAction | UndoAction | RedoAction;
 
 // @internal (undocumented)

--- a/packages/public/store/__tests__/history.ts
+++ b/packages/public/store/__tests__/history.ts
@@ -12,7 +12,13 @@ import {
   pureUndo,
   temporaryCommit,
 } from '../src/history/actions'
-import { getHistory, getRedoStack, getUndoStack } from '../src/history/reducer'
+import {
+  getHistory,
+  getRedoStack,
+  getUndoStack,
+  hasUndoActions,
+  hasRedoActions,
+} from '../src/history/reducer'
 
 let store: ReturnType<typeof setupStore>
 
@@ -468,6 +474,38 @@ test('Undo replace', async () => {
   expect(S.serializeDocument('1')(store.getState())).toEqual({
     plugin: 'stateful',
     state: 0,
+  })
+})
+
+describe('hasUndoActions()', () => {
+  beforeEach(async () => {
+    await change({ id: 'root', state: { initial: () => 1 } })
+  })
+
+  test('returns true when there are undo actions', () => {
+    expect(hasUndoActions()(store.getState())).toEqual(true)
+  })
+
+  test('returns false when there are undo actions', async () => {
+    await undo()
+
+    expect(hasUndoActions()(store.getState())).toEqual(false)
+  })
+})
+
+describe('hasRedoActions()', () => {
+  beforeEach(async () => {
+    await change({ id: 'root', state: { initial: () => 1 } })
+  })
+
+  test('returns true when there are undo actions', () => {
+    expect(hasRedoActions()(store.getState())).toEqual(false)
+  })
+
+  test('returns false when there are undo actions', async () => {
+    await undo()
+
+    expect(hasRedoActions()(store.getState())).toEqual(true)
   })
 })
 

--- a/packages/public/store/src/history/reducer.ts
+++ b/packages/public/store/src/history/reducer.ts
@@ -8,12 +8,7 @@ import {
   createSubReducer,
   SubReducer,
 } from '../helpers'
-import {
-  HistoryState,
-  InternalScopedState,
-  InternalSelector,
-  Selector,
-} from '../types'
+import { HistoryState, InternalSelector, Selector } from '../types'
 import {
   persist,
   PersistAction,
@@ -96,7 +91,7 @@ export const getHistory: InternalSelector<HistoryState> = createInternalSelector
 
 /** @public */
 export const getPendingChanges: Selector<number> = createSelector(
-  (state) => getHistory()(state as InternalScopedState).pendingChanges
+  (state) => state.history.pendingChanges
 )
 
 /** @public */
@@ -106,12 +101,12 @@ export const hasPendingChanges: Selector<boolean> = createSelector(
 
 /** @public */
 export const hasUndoActions: Selector<boolean> = createSelector(
-  (state) => getHistory()(state as InternalScopedState).undoStack.length > 0
+  (state) => state.history.undoStack.length > 0
 )
 
 /** @public */
 export const hasRedoActions: Selector<boolean> = createSelector(
-  (state) => getHistory()(state as InternalScopedState).redoStack.length > 0
+  (state) => state.history.redoStack.length > 0
 )
 
 /** @internal */

--- a/packages/public/store/src/history/reducer.ts
+++ b/packages/public/store/src/history/reducer.ts
@@ -104,6 +104,16 @@ export const hasPendingChanges: Selector<boolean> = createSelector(
   (state) => getPendingChanges()(state) !== 0
 )
 
+/** @public */
+export const hasUndoActions: Selector<boolean> = createSelector(
+  (state) => getHistory()(state as InternalScopedState).undoStack.length > 0
+)
+
+/** @public */
+export const hasRedoActions: Selector<boolean> = createSelector(
+  (state) => getHistory()(state as InternalScopedState).redoStack.length > 0
+)
+
 /** @internal */
 export const getUndoStack: InternalSelector<
   ReversibleAction[][]

--- a/packages/public/store/src/types.ts
+++ b/packages/public/store/src/types.ts
@@ -22,7 +22,11 @@ export interface ScopedState {
   focus: string | null
   root: string | null
   clipboard: DocumentState[]
-  history: unknown
+  history: {
+    undoStack: unknown[]
+    redoStack: unknown[]
+    pendingChanges: number
+  }
 }
 
 /** @internal */


### PR DESCRIPTION
Currently it is not possible to determine whether there are actions which can be redo. At serlo.org there is the line (see https://github.com/serlo/serlo.org/blob/cff526b0fddfa91240ba56c6047cb6a62e450dc1/packages/private/edtr-io/src/plugins/types/common.tsx#L108-L110 ):

```ts
const redoable = pendingChanges < 0
```

However, when I understand the code at https://github.com/edtr-io/edtr-io/blob/master/packages/public/store/src/history/reducer.ts correctly, pendingChanges is the total number of made actions starting from the beginning due to the current state. Thus, this number can never be negative. To test whether there are undo / redo actions it would be easier to check, whether `undoStack` or `redoStack` are empty or not.

**Sidenote:** The Selector `hasPendingChanges()` should be the same as `hasUndoActions()` and therefore this function might not be needed afterwards any more.

**Question:** Why is `hasPendingChanges()` available in serlo.org, but `getUndoStack()` not? Both files https://github.com/edtr-io/edtr-io/blob/master/packages/public/store/src/history/index.ts and https://github.com/edtr-io/edtr-io/blob/master/packages/public/store/src/index.ts export anything in https://github.com/edtr-io/edtr-io/blob/master/packages/public/store/src/history/reducer.ts Is this only due to the comments `/** @public */` and `/** @internal */`