### PR TITLE
math: Set position of overlay to "below"

### DIFF
--- a/packages/private/demo/__stories__/math.tsx
+++ b/packages/private/demo/__stories__/math.tsx
@@ -8,31 +8,32 @@ import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
 function MathEditorStory(props: Partial<MathEditorProps>) {
-  return (
-    <RootThemeProvider
-      theme={{ editor: defaultEditorTheme, renderer: defaultRendererTheme }}
-    >
-      <MathEditorExample {...props} />
-    </RootThemeProvider>
-  )
-}
-
-function MathEditorExample(props: Partial<MathEditorProps>) {
   const [state, onChange] = React.useState(props.state || '')
   const [visual, setVisual] = React.useState(props.visual === true)
   const [inline, setInline] = React.useState(props.inline === true)
 
   return (
-    <MathEditor
-      {...props}
-      visual={visual}
-      inline={inline}
-      state={state}
-      onEditorChange={setVisual}
-      onInlineChange={setInline}
-      onChange={onChange}
-      config={{}}
-    />
+    <RootThemeProvider
+      theme={{
+        editor: defaultEditorTheme,
+        renderer: defaultRendererTheme,
+      }}
+    >
+      <MathEditor
+        {...props}
+        visual={visual}
+        inline={inline}
+        state={state}
+        onEditorChange={(visual) => {
+          setVisual(visual)
+        }}
+        onInlineChange={(inline) => {
+          setInline(inline)
+        }}
+        onChange={onChange}
+        config={{}}
+      />
+    </RootThemeProvider>
   )
 }
 
@@ -67,7 +68,11 @@ storiesOf('Math', module)
   .add('MathEditor (block, focus on click)', () => {
     const [focused, setFocused] = React.useState(false)
     return (
-      <div onClick={() => setFocused(true)}>
+      <div
+        onClick={() => {
+          setFocused(true)
+        }}
+      >
         <MathEditorStory autofocus state="\sqrt{2}" readOnly={!focused} />
       </div>
     )
@@ -75,7 +80,11 @@ storiesOf('Math', module)
   .add('MathEditor (block, visual, focus on click)', () => {
     const [focused, setFocused] = React.useState(false)
     return (
-      <div onClick={() => setFocused(true)}>
+      <div
+        onClick={() => {
+          setFocused(true)
+        }}
+      >
         <MathEditorStory
           autofocus
           state="\sqrt{2}"
@@ -83,26 +92,5 @@ storiesOf('Math', module)
           visual
         />
       </div>
-    )
-  })
-  .add('MathEditor (Overlay does not hide previous text)', () => {
-    return (
-      <RootThemeProvider
-        theme={{ editor: defaultEditorTheme, renderer: defaultRendererTheme }}
-      >
-        <p>
-          Consequatur quos vitae vel in. Suscipit a eius deserunt nisi neque.
-          Minima dolores quia quo veritatis. Aut natus nihil necessitatibus
-          delectus ea eligendi dolor sit. Neque deleniti vel sint laborum et
-          quia.
-        </p>
-
-        <p>
-          Voluptatem similique perspiciatis earum eius fugit officiis ut et.
-          Numquam laudantium ut ipsum. Fugiat voluptatum dolores sit maiores.
-        </p>
-
-        <MathEditorExample state="\sqrt{2}" visual />
-      </RootThemeProvider>
     )
   })

--- a/packages/private/demo/__stories__/math.tsx
+++ b/packages/private/demo/__stories__/math.tsx
@@ -8,32 +8,31 @@ import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
 function MathEditorStory(props: Partial<MathEditorProps>) {
+  return (
+    <RootThemeProvider
+      theme={{ editor: defaultEditorTheme, renderer: defaultRendererTheme }}
+    >
+      <MathEditorExample {...props} />
+    </RootThemeProvider>
+  )
+}
+
+function MathEditorExample(props: Partial<MathEditorProps>) {
   const [state, onChange] = React.useState(props.state || '')
   const [visual, setVisual] = React.useState(props.visual === true)
   const [inline, setInline] = React.useState(props.inline === true)
 
   return (
-    <RootThemeProvider
-      theme={{
-        editor: defaultEditorTheme,
-        renderer: defaultRendererTheme,
-      }}
-    >
-      <MathEditor
-        {...props}
-        visual={visual}
-        inline={inline}
-        state={state}
-        onEditorChange={(visual) => {
-          setVisual(visual)
-        }}
-        onInlineChange={(inline) => {
-          setInline(inline)
-        }}
-        onChange={onChange}
-        config={{}}
-      />
-    </RootThemeProvider>
+    <MathEditor
+      {...props}
+      visual={visual}
+      inline={inline}
+      state={state}
+      onEditorChange={setVisual}
+      onInlineChange={setInline}
+      onChange={onChange}
+      config={{}}
+    />
   )
 }
 
@@ -68,11 +67,7 @@ storiesOf('Math', module)
   .add('MathEditor (block, focus on click)', () => {
     const [focused, setFocused] = React.useState(false)
     return (
-      <div
-        onClick={() => {
-          setFocused(true)
-        }}
-      >
+      <div onClick={() => setFocused(true)}>
         <MathEditorStory autofocus state="\sqrt{2}" readOnly={!focused} />
       </div>
     )
@@ -80,11 +75,7 @@ storiesOf('Math', module)
   .add('MathEditor (block, visual, focus on click)', () => {
     const [focused, setFocused] = React.useState(false)
     return (
-      <div
-        onClick={() => {
-          setFocused(true)
-        }}
-      >
+      <div onClick={() => setFocused(true)}>
         <MathEditorStory
           autofocus
           state="\sqrt{2}"
@@ -92,5 +83,26 @@ storiesOf('Math', module)
           visual
         />
       </div>
+    )
+  })
+  .add('MathEditor (Overlay does not hide previous text)', () => {
+    return (
+      <RootThemeProvider
+        theme={{ editor: defaultEditorTheme, renderer: defaultRendererTheme }}
+      >
+        <p>
+          Consequatur quos vitae vel in. Suscipit a eius deserunt nisi neque.
+          Minima dolores quia quo veritatis. Aut natus nihil necessitatibus
+          delectus ea eligendi dolor sit. Neque deleniti vel sint laborum et
+          quia.
+        </p>
+
+        <p>
+          Voluptatem similique perspiciatis earum eius fugit officiis ut et.
+          Numquam laudantium ut ipsum. Fugiat voluptatum dolores sit maiores.
+        </p>
+
+        <MathEditorExample state="\sqrt{2}" visual />
+      </RootThemeProvider>
     )
   })

--- a/packages/public/math/src/editor.tsx
+++ b/packages/public/math/src/editor.tsx
@@ -239,7 +239,7 @@ export function MathEditor(props: MathEditorProps) {
         )}
         {helpOpen ? null : (
           <HoverOverlay
-            position="above"
+            position="below"
             anchor={anchorRef}
             allowSelectionOverflow
           >


### PR DESCRIPTION
The overlay should not hide previous text and thus the default position
of the overlay shall be "below". We got this feedback from the authors
at serlo.org.