### PR TITLE
Set overlay of math editor to above

### DIFF
--- a/packages/public/math/src/editor.tsx
+++ b/packages/public/math/src/editor.tsx
@@ -239,7 +239,7 @@ export function MathEditor(props: MathEditorProps) {
         )}
         {helpOpen ? null : (
           <HoverOverlay
-            position="below"
+            position="above"
             anchor={anchorRef}
             allowSelectionOverflow
           >


### PR DESCRIPTION
After the feedback I got from @kathongi the overlay shall be shown above again.