### PR TITLE
`noLinebreaks` also disables block math

### DIFF
--- a/packages/plugins/text/src/plugins/katex/editor.tsx
+++ b/packages/plugins/text/src/plugins/katex/editor.tsx
@@ -38,7 +38,8 @@ export const DefaultEditorComponent: React.FunctionComponent<
       visual={preferences.getKey(preferenceKey) === true}
       disableBlock={
         isList(orderedListNode)(editor.controller) ||
-        isList(unorderedListNode)(editor.controller)
+        isList(unorderedListNode)(editor.controller) ||
+        props.config.noLinebreaks
       }
       config={{
         i18n: props.config.i18n.math,


### PR DESCRIPTION
(not urgent)