### PR TITLE
load esm module from cjs

### DIFF
--- a/packages/public/store/src/store.ts
+++ b/packages/public/store/src/store.ts
@@ -1,5 +1,4 @@
 import { EditorPlugin } from '@edtr-io/internal__plugin'
-import { defaultImport } from 'default-import'
 import * as R from 'ramda'
 import {
   applyMiddleware,
@@ -16,7 +15,7 @@ import { serializeRootDocument } from './root/reducer'
 import { saga } from './saga'
 import { InternalState, SelectorReturnType, State } from './types'
 
-const createSagaMiddleware = defaultImport(_createSagaMiddleware)
+const createSagaMiddleware = _createSagaMiddleware
 
 /**
  * Creates the Edtr.io store

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -20,16 +20,18 @@ type ExtractDefault<T> = T extends {
     : U
   : T
 
-function defaultImport<T>(mod: T): ExtractDefault<T> {
+function defaultImport<T>(mod_: T): ExtractDefault<T> {
+  const mod = mod_ as any
   if (typeof mod !== 'object' || mod === null) {
     return mod as ExtractDefault<T>
   }
   // Webpack provides a Module tag to match NodeJS' Module module
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const defaultVal =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (mod as any).default ?? mod
+        mod.default ?? mod
       : mod
   if (
     '__esModule' in defaultVal &&

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -5,8 +5,10 @@ import {
 } from '@fortawesome/react-fontawesome'
 import * as R from 'ramda'
 import * as React from 'react'
+import _styled from 'styled-components'
 
-import { styled } from '.'
+const { defaultImport } = await import('default-import')
+const styled = defaultImport(_styled)
 
 /**
  * Font Awesome Icon component

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -5,8 +5,7 @@ import {
 } from '@fortawesome/react-fontawesome'
 import * as R from 'ramda'
 import * as React from 'react'
-
-import { styled } from '.'
+import styled from 'styled-components'
 
 /**
  * Font Awesome Icon component
@@ -108,7 +107,9 @@ export function createIcon(i: IconDefinition): React.ComponentType {
   }
 }
 
-const EdtrSVG = styled.svg({
+// @ts-expect-error https://github.com/serlo/serlo-editor-issues-and-documentation/issues/68
+const styledSvg = styled.default?.svg ? styled.default.svg : styled.svg
+const EdtrSVG = styledSvg({
   display: 'inline-block',
   verticalAlign: 'middle',
   overflow: 'hidden',

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -7,7 +7,29 @@ import * as R from 'ramda'
 import * as React from 'react'
 import _styled from 'styled-components'
 
-const { defaultImport } = await import('default-import')
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const defaultImport = (mod: any) => {
+  if (typeof mod !== 'object' || mod === null) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return mod
+  }
+  // Webpack provides a Module tag to match NodeJS' Module module
+  const defaultVal =
+    Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
+      ? mod.default ?? mod
+      : mod
+  if (
+    '__esModule' in defaultVal &&
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    defaultVal.__esModule &&
+    defaultVal.default !== undefined
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return defaultVal.default
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return defaultVal
+}
 const styled = defaultImport(_styled)
 
 /**

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -3,12 +3,10 @@ import {
   FontAwesomeIcon,
   FontAwesomeIconProps,
 } from '@fortawesome/react-fontawesome'
-import { defaultImport } from 'default-import'
 import * as R from 'ramda'
 import * as React from 'react'
-import _styled from 'styled-components'
 
-const styled = defaultImport(_styled)
+import { styled } from '.'
 
 /**
  * Font Awesome Icon component

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import {
   FontAwesomeIcon,
@@ -6,47 +5,8 @@ import {
 } from '@fortawesome/react-fontawesome'
 import * as R from 'ramda'
 import * as React from 'react'
-import _styled from 'styled-components'
 
-type ExtractDefault<T> = T extends {
-  __esModule?: boolean
-  default: infer U
-}
-  ? U extends {
-      __esModule?: boolean
-      default: infer V
-    }
-    ? V
-    : U
-  : T
-
-function defaultImport<T>(mod_: T): ExtractDefault<T> {
-  const mod = mod_ as any
-  if (typeof mod !== 'object' || mod === null) {
-    return mod as ExtractDefault<T>
-  }
-  // Webpack provides a Module tag to match NodeJS' Module module
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const defaultVal =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
-      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        mod.default ?? mod
-      : mod
-  if (
-    '__esModule' in defaultVal &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    defaultVal.__esModule &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    defaultVal.default !== undefined
-  ) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return defaultVal.default as ExtractDefault<T>
-  }
-  return defaultVal as ExtractDefault<T>
-}
-
-const styled = defaultImport(_styled)
+import { styled } from '.'
 
 /**
  * Font Awesome Icon component

--- a/packages/public/ui/src/icon.tsx
+++ b/packages/public/ui/src/icon.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import {
   FontAwesomeIcon,
@@ -7,29 +8,42 @@ import * as R from 'ramda'
 import * as React from 'react'
 import _styled from 'styled-components'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultImport = (mod: any) => {
+type ExtractDefault<T> = T extends {
+  __esModule?: boolean
+  default: infer U
+}
+  ? U extends {
+      __esModule?: boolean
+      default: infer V
+    }
+    ? V
+    : U
+  : T
+
+function defaultImport<T>(mod: T): ExtractDefault<T> {
   if (typeof mod !== 'object' || mod === null) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return mod
+    return mod as ExtractDefault<T>
   }
   // Webpack provides a Module tag to match NodeJS' Module module
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const defaultVal =
     Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
-      ? mod.default ?? mod
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (mod as any).default ?? mod
       : mod
   if (
     '__esModule' in defaultVal &&
-    // eslint-disable-next-line @typescript-eslint/naming-convention
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     defaultVal.__esModule &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     defaultVal.default !== undefined
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return defaultVal.default
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return defaultVal.default as ExtractDefault<T>
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return defaultVal
+  return defaultVal as ExtractDefault<T>
 }
+
 const styled = defaultImport(_styled)
 
 /**

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /**
  * Provides utils for the User Interface
  *
@@ -5,7 +7,29 @@
  */
 import _styled from 'styled-components'
 
-const { defaultImport } = await import('default-import')
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const defaultImport = (mod: any) => {
+  if (typeof mod !== 'object' || mod === null) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return mod
+  }
+  // Webpack provides a Module tag to match NodeJS' Module module
+  const defaultVal =
+    Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
+      ? mod.default ?? mod
+      : mod
+  if (
+    '__esModule' in defaultVal &&
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    defaultVal.__esModule &&
+    defaultVal.default !== undefined
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return defaultVal.default
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return defaultVal
+}
 
 /**
  * Re-export of {@link https://styled-components.com/docs/api#primary | `styled` in `styled-components` }

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -18,16 +18,19 @@ type ExtractDefault<T> = T extends {
     : U
   : T
 
-function defaultImport<T>(mod: T): ExtractDefault<T> {
+function defaultImport<T>(mod_: T): ExtractDefault<T> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const mod = mod_ as any
   if (typeof mod !== 'object' || mod === null) {
     return mod as ExtractDefault<T>
   }
   // Webpack provides a Module tag to match NodeJS' Module module
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const defaultVal =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (mod as any).default ?? mod
+        mod.default ?? mod
       : mod
   if (
     '__esModule' in defaultVal &&

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -6,15 +6,15 @@
  */
 import _styled, { StyledInterface } from 'styled-components'
 
+// See https://github.com/serlo/serlo-editor-issues-and-documentation/issues/68
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const __styled = _styled as any
+
 /**
  * Re-export of {@link https://styled-components.com/docs/api#primary | `styled` in `styled-components` }
  *
  * @public
  */
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const __styled = _styled as any
-
 export const styled =
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   (__styled.default?.svg ? __styled.default : _styled) as StyledInterface

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Provides utils for the User Interface
  *
@@ -7,28 +6,40 @@
  */
 import _styled from 'styled-components'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultImport = (mod: any) => {
+type ExtractDefault<T> = T extends {
+  __esModule?: boolean
+  default: infer U
+}
+  ? U extends {
+      __esModule?: boolean
+      default: infer V
+    }
+    ? V
+    : U
+  : T
+
+function defaultImport<T>(mod: T): ExtractDefault<T> {
   if (typeof mod !== 'object' || mod === null) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return mod
+    return mod as ExtractDefault<T>
   }
   // Webpack provides a Module tag to match NodeJS' Module module
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const defaultVal =
     Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
-      ? mod.default ?? mod
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (mod as any).default ?? mod
       : mod
   if (
     '__esModule' in defaultVal &&
-    // eslint-disable-next-line @typescript-eslint/naming-convention
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     defaultVal.__esModule &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     defaultVal.default !== undefined
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return defaultVal.default
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return defaultVal.default as ExtractDefault<T>
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return defaultVal
+  return defaultVal as ExtractDefault<T>
 }
 
 /**

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -1,10 +1,11 @@
-import { defaultImport } from 'default-import'
 /**
  * Provides utils for the User Interface
  *
  * @packageDocumentation
  */
 import _styled from 'styled-components'
+
+const { defaultImport } = await import('default-import')
 
 /**
  * Re-export of {@link https://styled-components.com/docs/api#primary | `styled` in `styled-components` }

--- a/packages/public/ui/src/index.ts
+++ b/packages/public/ui/src/index.ts
@@ -4,53 +4,20 @@
  *
  * @packageDocumentation
  */
-import _styled from 'styled-components'
-
-type ExtractDefault<T> = T extends {
-  __esModule?: boolean
-  default: infer U
-}
-  ? U extends {
-      __esModule?: boolean
-      default: infer V
-    }
-    ? V
-    : U
-  : T
-
-function defaultImport<T>(mod_: T): ExtractDefault<T> {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const mod = mod_ as any
-  if (typeof mod !== 'object' || mod === null) {
-    return mod as ExtractDefault<T>
-  }
-  // Webpack provides a Module tag to match NodeJS' Module module
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const defaultVal =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    Symbol.toStringTag in mod && mod[Symbol.toStringTag] === 'Module'
-      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        mod.default ?? mod
-      : mod
-  if (
-    '__esModule' in defaultVal &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    defaultVal.__esModule &&
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    defaultVal.default !== undefined
-  ) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return defaultVal.default as ExtractDefault<T>
-  }
-  return defaultVal as ExtractDefault<T>
-}
+import _styled, { StyledInterface } from 'styled-components'
 
 /**
  * Re-export of {@link https://styled-components.com/docs/api#primary | `styled` in `styled-components` }
  *
  * @public
  */
-export const styled = defaultImport(_styled)
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const __styled = _styled as any
+
+export const styled =
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  (__styled.default?.svg ? __styled.default : _styled) as StyledInterface
 
 export * from './deep-partial'
 export * from './editor-theme'


### PR DESCRIPTION
Avoid using `default-import` package, it's needed in the ui package, so we include the source code directly (mostly bypassing type-checking for now)

